### PR TITLE
Add hooks for extension support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = "0.8.1"
 image = { version = "0.23.12", default-features = false, features = ["jpeg"] }
 
 [features]
+# Optimizations and features
 default = ["std"]
 async = ["std", "async-io", "async-net", "blocking", "futures-io", "futures-lite"]
 image-support = ["image", "std"]
@@ -38,6 +39,10 @@ nightly-const-optimization = []
 nightly-min-specialization = []
 parallel = ["rayon", "std"]
 std = []
+
+# Extensions
+render = []
+all-extensions = ["render"]
 
 [package.metadata.docs.rs]
 features = ["async"]

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OUTPUT = $(PWD)/src/auto
 RUSTFMT = rustfmt
 
 #AUTOS = $(foreach f,$(notdir $(wildcard $(XML)/*.xml)),$(OUTPUT)/$(f:.xml=.rs))
-AUTOS = $(OUTPUT)/xproto.rs $(OUTPUT)/xc_misc.rs
+AUTOS = $(OUTPUT)/xproto.rs $(OUTPUT)/xc_misc.rs $(OUTPUT)/render.rs
 
 autos: $(AUTOS) 
 

--- a/generator/src/lvl2/state.rs
+++ b/generator/src/lvl2/state.rs
@@ -371,6 +371,23 @@ fn normalize_fields(fields: &mut TinyVec<[StructureItem; 6]>) {
                 let lname = l.name.clone();
                 let item = item.to_owned();
 
+                // check and make sure none of the other lists in this series have this item
+                // as a single item
+                if fields.iter().any(|f| {
+                    if let StructureItem::List(l) = f {
+                        if let Some(len_name) = l.list_length.single_item() {
+                            if l.name != lname && len_name == item {
+                                return true;
+                            }
+                        }
+                    }
+
+                    false
+                }) {
+                    log::info!("Found duplicate single item: {}", &item);
+                    continue;
+                }
+
                 // if this is a single-item list length, axe that single item and
                 // just use Vec::len() to calculate length
                 fields.iter_mut().any(move |f| {

--- a/generator/src/lvl3/bitflags.rs
+++ b/generator/src/lvl3/bitflags.rs
@@ -62,7 +62,7 @@ pub fn bitflags_to_lvl3(bitflags: Bitflags) -> Vec<RStruct> {
                     ty: Type::Basic("bool".into()),
                     usage: ParameterUsage::Owned,
                 }],
-                Some(Type::Ref(Box::new(Type::Basic("Self".into())), true)),
+                Some(Type::Ref(Box::new(Type::Basic("Self".into())), true, None)),
             );
 
             method.statements.extend(vec![

--- a/generator/src/lvl3/item.rs
+++ b/generator/src/lvl3/item.rs
@@ -82,12 +82,12 @@ impl ToSyn for Item {
 
 impl Item {
     #[inline]
-    pub fn from_lvl2(lvl2: Lvl2Item, xids: &[Box<str>]) -> Vec<Self> {
+    pub fn from_lvl2(lvl2: Lvl2Item, xids: &[Box<str>], ext_name: Option<&str>) -> Vec<Self> {
         match lvl2 {
             Lvl2Item::Import(i) => vec![Item::Import(i)],
             Lvl2Item::Typedef(t) => vec![Item::Typedef(t)],
             Lvl2Item::Struct(s) => {
-                let (mut rs1, mut rs2) = <(RStruct, Option<RStruct>)>::from(s);
+                let (mut rs1, mut rs2) = RStruct::from_prev(s, ext_name);
                 rs1.populate_asb();
                 if let Some(ref mut rs2) = rs2 {
                     rs2.populate_asb();

--- a/generator/src/lvl3/ty.rs
+++ b/generator/src/lvl3/ty.rs
@@ -22,7 +22,7 @@ pub enum Type {
     /// Tuple container type.
     Tuple(Vec<Type>),
     /// Reference to another type.
-    Ref(Box<Type>, bool),
+    Ref(Box<Type>, bool, Option<&'static str>),
     /// Slice of a type.
     Slice(Box<Type>),
 }
@@ -68,9 +68,12 @@ impl Type {
                 paren_token: Default::default(),
                 elems: tys.iter().map(|t| t.to_syn_ty()).collect(),
             }),
-            Self::Ref(r, is_mut) => syn::Type::Reference(syn::TypeReference {
+            Self::Ref(r, is_mut, lifetime) => syn::Type::Reference(syn::TypeReference {
                 and_token: Default::default(),
-                lifetime: None,
+                lifetime: match lifetime {
+                    None => None,
+                    Some(lifetime) => Some(syn::Lifetime::new(lifetime, Span::call_site())),
+                },
                 mutability: if *is_mut {
                     Some(Default::default())
                 } else {

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -319,6 +319,9 @@ impl AsByteSequence for String {
 //pub mod render;
 //pub mod shape;
 //pub mod xfixes;
+/// The X Rendering composite system.
+#[cfg(feature = "render")]
+pub mod render;
 /// Miscellaneous additions to the X11 protocol.
 pub mod xc_misc;
 /// The core X11 protocol.

--- a/src/auto/render.rs
+++ b/src/auto/render.rs
@@ -1,0 +1,4310 @@
+// This file was automatically generated.
+// It is considered to be licensed under the MIT and Apache 2.0 licenses.
+
+#![allow(warnings)]
+
+use super::prelude::*;
+
+use super::xproto::*;
+pub type Glyph = Card32;
+#[repr(transparent)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Glyphset {
+    pub xid: XID,
+}
+impl Glyphset {
+    #[inline]
+    pub const fn const_from_xid(xid: XID) -> Self {
+        Self { xid: xid }
+    }
+}
+impl XidType for Glyphset {
+    #[inline]
+    fn xid(&self) -> XID {
+        self.xid
+    }
+    #[inline]
+    fn from_xid(xid: XID) -> Self {
+        Self { xid: xid }
+    }
+}
+#[repr(transparent)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Picture {
+    pub xid: XID,
+}
+impl Picture {
+    #[inline]
+    pub const fn const_from_xid(xid: XID) -> Self {
+        Self { xid: xid }
+    }
+}
+impl XidType for Picture {
+    #[inline]
+    fn xid(&self) -> XID {
+        self.xid
+    }
+    #[inline]
+    fn from_xid(xid: XID) -> Self {
+        Self { xid: xid }
+    }
+}
+#[repr(transparent)]
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Pictformat {
+    pub xid: XID,
+}
+impl Pictformat {
+    #[inline]
+    pub const fn const_from_xid(xid: XID) -> Self {
+        Self { xid: xid }
+    }
+}
+impl XidType for Pictformat {
+    #[inline]
+    fn xid(&self) -> XID {
+        self.xid
+    }
+    #[inline]
+    fn from_xid(xid: XID) -> Self {
+        Self { xid: xid }
+    }
+}
+pub type Fixed = Int32;
+#[derive(Clone, Debug, Default)]
+pub struct Directformat {
+    pub red_shift: Card16,
+    pub red_mask: Card16,
+    pub green_shift: Card16,
+    pub green_mask: Card16,
+    pub blue_shift: Card16,
+    pub blue_mask: Card16,
+    pub alpha_shift: Card16,
+    pub alpha_mask: Card16,
+}
+impl Directformat {}
+impl AsByteSequence for Directformat {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.red_shift.as_bytes(&mut bytes[index..]);
+        index += self.red_mask.as_bytes(&mut bytes[index..]);
+        index += self.green_shift.as_bytes(&mut bytes[index..]);
+        index += self.green_mask.as_bytes(&mut bytes[index..]);
+        index += self.blue_shift.as_bytes(&mut bytes[index..]);
+        index += self.blue_mask.as_bytes(&mut bytes[index..]);
+        index += self.alpha_shift.as_bytes(&mut bytes[index..]);
+        index += self.alpha_mask.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Directformat from byte buffer");
+        let (red_shift, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (red_mask, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (green_shift, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (green_mask, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (blue_shift, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (blue_mask, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (alpha_shift, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (alpha_mask, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Directformat {
+                red_shift: red_shift,
+                red_mask: red_mask,
+                green_shift: green_shift,
+                green_mask: green_mask,
+                blue_shift: blue_shift,
+                blue_mask: blue_mask,
+                alpha_shift: alpha_shift,
+                alpha_mask: alpha_mask,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.red_shift.size()
+            + self.red_mask.size()
+            + self.green_shift.size()
+            + self.green_mask.size()
+            + self.blue_shift.size()
+            + self.blue_mask.size()
+            + self.alpha_shift.size()
+            + self.alpha_mask.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Pictforminfo {
+    pub id: Pictformat,
+    pub ty: PictType,
+    pub depth: Card8,
+    pub direct: Directformat,
+    pub colormap: Colormap,
+}
+impl Pictforminfo {}
+impl AsByteSequence for Pictforminfo {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.id.as_bytes(&mut bytes[index..]);
+        index += self.ty.as_bytes(&mut bytes[index..]);
+        index += self.depth.as_bytes(&mut bytes[index..]);
+        index += 2;
+        index += self.direct.as_bytes(&mut bytes[index..]);
+        index += self.colormap.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Pictforminfo from byte buffer");
+        let (id, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (ty, sz): (PictType, usize) = <PictType>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (depth, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 2;
+        let (direct, sz): (Directformat, usize) = <Directformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (colormap, sz): (Colormap, usize) = <Colormap>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Pictforminfo {
+                id: id,
+                ty: ty,
+                depth: depth,
+                direct: direct,
+                colormap: colormap,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.id.size()
+            + self.ty.size()
+            + self.depth.size()
+            + 2
+            + self.direct.size()
+            + self.colormap.size()
+    }
+}
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PictType {
+    Indexed = 0,
+    Direct = 1,
+}
+impl AsByteSequence for PictType {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        (*self as u8).as_bytes(bytes)
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let (underlying, sz): (u8, usize) = <u8>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Indexed, sz)),
+            1 => Some((Self::Direct, sz)),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        ::core::mem::size_of::<u8>()
+    }
+}
+impl Default for PictType {
+    #[inline]
+    fn default() -> PictType {
+        PictType::Indexed
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Pictvisual {
+    pub visual: Visualid,
+    pub format: Pictformat,
+}
+impl Pictvisual {}
+impl AsByteSequence for Pictvisual {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.visual.as_bytes(&mut bytes[index..]);
+        index += self.format.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Pictvisual from byte buffer");
+        let (visual, sz): (Visualid, usize) = <Visualid>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Pictvisual {
+                visual: visual,
+                format: format,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.visual.size() + self.format.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Pictdepth {
+    pub depth: Card8,
+    pub visuals: Vec<Pictvisual>,
+}
+impl Pictdepth {}
+impl AsByteSequence for Pictdepth {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.depth.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += (self.visuals.len() as Card16).as_bytes(&mut bytes[index..]);
+        index += 4;
+        let block_len: usize = vector_as_bytes(&self.visuals, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictvisual>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Pictdepth from byte buffer");
+        let (depth, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (len0, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 4;
+        let (visuals, block_len): (Vec<Pictvisual>, usize) =
+            vector_from_bytes(&bytes[index..], len0 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictvisual>());
+        Some((
+            Pictdepth {
+                depth: depth,
+                visuals: visuals,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.depth.size() + 1 + ::core::mem::size_of::<Card16>() + 4 + {
+            let block_len: usize = self.visuals.iter().map(|i| i.size()).sum();
+            let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Pictvisual>());
+            block_len + pad
+        }
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Pictscreen {
+    pub fallback: Pictformat,
+    pub depths: Vec<Pictdepth>,
+}
+impl Pictscreen {}
+impl AsByteSequence for Pictscreen {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += (self.depths.len() as Card32).as_bytes(&mut bytes[index..]);
+        index += self.fallback.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.depths, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictdepth>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Pictscreen from byte buffer");
+        let (len0, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (fallback, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (depths, block_len): (Vec<Pictdepth>, usize) =
+            vector_from_bytes(&bytes[index..], len0 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictdepth>());
+        Some((
+            Pictscreen {
+                fallback: fallback,
+                depths: depths,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        ::core::mem::size_of::<Card32>() + self.fallback.size() + {
+            let block_len: usize = self.depths.iter().map(|i| i.size()).sum();
+            let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Pictdepth>());
+            block_len + pad
+        }
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Indexvalue {
+    pub pixel: Card32,
+    pub red: Card16,
+    pub green: Card16,
+    pub blue: Card16,
+    pub alpha: Card16,
+}
+impl Indexvalue {}
+impl AsByteSequence for Indexvalue {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.pixel.as_bytes(&mut bytes[index..]);
+        index += self.red.as_bytes(&mut bytes[index..]);
+        index += self.green.as_bytes(&mut bytes[index..]);
+        index += self.blue.as_bytes(&mut bytes[index..]);
+        index += self.alpha.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Indexvalue from byte buffer");
+        let (pixel, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (red, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (green, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (blue, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (alpha, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Indexvalue {
+                pixel: pixel,
+                red: red,
+                green: green,
+                blue: blue,
+                alpha: alpha,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.pixel.size()
+            + self.red.size()
+            + self.green.size()
+            + self.blue.size()
+            + self.alpha.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Color {
+    pub red: Card16,
+    pub green: Card16,
+    pub blue: Card16,
+    pub alpha: Card16,
+}
+impl Color {}
+impl AsByteSequence for Color {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.red.as_bytes(&mut bytes[index..]);
+        index += self.green.as_bytes(&mut bytes[index..]);
+        index += self.blue.as_bytes(&mut bytes[index..]);
+        index += self.alpha.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Color from byte buffer");
+        let (red, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (green, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (blue, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (alpha, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Color {
+                red: red,
+                green: green,
+                blue: blue,
+                alpha: alpha,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.red.size() + self.green.size() + self.blue.size() + self.alpha.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Pointfix {
+    pub x: Fixed,
+    pub y: Fixed,
+}
+impl Pointfix {}
+impl AsByteSequence for Pointfix {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Pointfix from byte buffer");
+        let (x, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((Pointfix { x: x, y: y }, index))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.x.size() + self.y.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Linefix {
+    pub p1: Pointfix,
+    pub p2: Pointfix,
+}
+impl Linefix {}
+impl AsByteSequence for Linefix {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.p1.as_bytes(&mut bytes[index..]);
+        index += self.p2.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Linefix from byte buffer");
+        let (p1, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (p2, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((Linefix { p1: p1, p2: p2 }, index))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.p1.size() + self.p2.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Triangle {
+    pub p1: Pointfix,
+    pub p2: Pointfix,
+    pub p3: Pointfix,
+}
+impl Triangle {}
+impl AsByteSequence for Triangle {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.p1.as_bytes(&mut bytes[index..]);
+        index += self.p2.as_bytes(&mut bytes[index..]);
+        index += self.p3.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Triangle from byte buffer");
+        let (p1, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (p2, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (p3, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Triangle {
+                p1: p1,
+                p2: p2,
+                p3: p3,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.p1.size() + self.p2.size() + self.p3.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Trapezoid {
+    pub top: Fixed,
+    pub bottom: Fixed,
+    pub left: Linefix,
+    pub right: Linefix,
+}
+impl Trapezoid {}
+impl AsByteSequence for Trapezoid {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.top.as_bytes(&mut bytes[index..]);
+        index += self.bottom.as_bytes(&mut bytes[index..]);
+        index += self.left.as_bytes(&mut bytes[index..]);
+        index += self.right.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Trapezoid from byte buffer");
+        let (top, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bottom, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (left, sz): (Linefix, usize) = <Linefix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (right, sz): (Linefix, usize) = <Linefix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Trapezoid {
+                top: top,
+                bottom: bottom,
+                left: left,
+                right: right,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.top.size() + self.bottom.size() + self.left.size() + self.right.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Glyphinfo {
+    pub width: Card16,
+    pub height: Card16,
+    pub x: Int16,
+    pub y: Int16,
+    pub x_off: Int16,
+    pub y_off: Int16,
+}
+impl Glyphinfo {}
+impl AsByteSequence for Glyphinfo {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.width.as_bytes(&mut bytes[index..]);
+        index += self.height.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index += self.x_off.as_bytes(&mut bytes[index..]);
+        index += self.y_off.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Glyphinfo from byte buffer");
+        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x_off, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y_off, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Glyphinfo {
+                width: width,
+                height: height,
+                x: x,
+                y: y,
+                x_off: x_off,
+                y_off: y_off,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.width.size()
+            + self.height.size()
+            + self.x.size()
+            + self.y.size()
+            + self.x_off.size()
+            + self.y_off.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryVersionRequest {
+    pub req_type: u8,
+    pub client_major_version: Card32,
+    pub length: u16,
+    pub client_minor_version: Card32,
+}
+impl QueryVersionRequest {}
+impl AsByteSequence for QueryVersionRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.client_major_version.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.client_minor_version.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryVersionRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (client_major_version, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (client_minor_version, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            QueryVersionRequest {
+                req_type: req_type,
+                client_major_version: client_major_version,
+                length: length,
+                client_minor_version: client_minor_version,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.client_major_version.size()
+            + self.length.size()
+            + self.client_minor_version.size()
+    }
+}
+impl Request for QueryVersionRequest {
+    const OPCODE: u8 = 0;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = QueryVersionReply;
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryVersionReply {
+    pub reply_type: u8,
+    pub sequence: u16,
+    pub length: u32,
+    pub major_version: Card32,
+    pub minor_version: Card32,
+}
+impl QueryVersionReply {}
+impl AsByteSequence for QueryVersionReply {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.reply_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.major_version.as_bytes(&mut bytes[index..]);
+        index += self.minor_version.as_bytes(&mut bytes[index..]);
+        index += 16;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryVersionReply from byte buffer");
+        let (reply_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u32, usize) = <u32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_version, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_version, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 16;
+        Some((
+            QueryVersionReply {
+                reply_type: reply_type,
+                sequence: sequence,
+                length: length,
+                major_version: major_version,
+                minor_version: minor_version,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.reply_type.size()
+            + 1
+            + self.sequence.size()
+            + self.length.size()
+            + self.major_version.size()
+            + self.minor_version.size()
+            + 16
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryPictFormatsRequest {
+    pub req_type: u8,
+    pub length: u16,
+}
+impl QueryPictFormatsRequest {}
+impl AsByteSequence for QueryPictFormatsRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryPictFormatsRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            QueryPictFormatsRequest {
+                req_type: req_type,
+                length: length,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + 1 + self.length.size()
+    }
+}
+impl Request for QueryPictFormatsRequest {
+    const OPCODE: u8 = 1;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = QueryPictFormatsReply;
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryPictFormatsReply {
+    pub reply_type: u8,
+    pub sequence: u16,
+    pub length: u32,
+    pub num_depths: Card32,
+    pub num_visuals: Card32,
+    pub formats: Vec<Pictforminfo>,
+    pub screens: Vec<Pictscreen>,
+    pub subpixels: Vec<Card32>,
+}
+impl QueryPictFormatsReply {}
+impl AsByteSequence for QueryPictFormatsReply {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.reply_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += (self.formats.len() as Card32).as_bytes(&mut bytes[index..]);
+        index += (self.screens.len() as Card32).as_bytes(&mut bytes[index..]);
+        index += self.num_depths.as_bytes(&mut bytes[index..]);
+        index += self.num_visuals.as_bytes(&mut bytes[index..]);
+        index += (self.subpixels.len() as Card32).as_bytes(&mut bytes[index..]);
+        index += 4;
+        let block_len: usize = vector_as_bytes(&self.formats, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictforminfo>());
+        let block_len: usize = vector_as_bytes(&self.screens, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictscreen>());
+        let block_len: usize = vector_as_bytes(&self.subpixels, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Card32>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryPictFormatsReply from byte buffer");
+        let (reply_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u32, usize) = <u32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (len0, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (len1, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (num_depths, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (num_visuals, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (len2, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 4;
+        let (formats, block_len): (Vec<Pictforminfo>, usize) =
+            vector_from_bytes(&bytes[index..], len0 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictforminfo>());
+        let (screens, block_len): (Vec<Pictscreen>, usize) =
+            vector_from_bytes(&bytes[index..], len1 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pictscreen>());
+        let (subpixels, block_len): (Vec<Card32>, usize) =
+            vector_from_bytes(&bytes[index..], len2 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Card32>());
+        Some((
+            QueryPictFormatsReply {
+                reply_type: reply_type,
+                sequence: sequence,
+                length: length,
+                num_depths: num_depths,
+                num_visuals: num_visuals,
+                formats: formats,
+                screens: screens,
+                subpixels: subpixels,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.reply_type.size()
+            + 1
+            + self.sequence.size()
+            + self.length.size()
+            + ::core::mem::size_of::<Card32>()
+            + ::core::mem::size_of::<Card32>()
+            + self.num_depths.size()
+            + self.num_visuals.size()
+            + ::core::mem::size_of::<Card32>()
+            + 4
+            + {
+                let block_len: usize = self.formats.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Pictforminfo>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.screens.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Pictscreen>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.subpixels.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Card32>());
+                block_len + pad
+            }
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryPictIndexValuesRequest {
+    pub req_type: u8,
+    pub format: Pictformat,
+    pub length: u16,
+}
+impl QueryPictIndexValuesRequest {}
+impl AsByteSequence for QueryPictIndexValuesRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.format.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryPictIndexValuesRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            QueryPictIndexValuesRequest {
+                req_type: req_type,
+                format: format,
+                length: length,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.format.size() + self.length.size()
+    }
+}
+impl Request for QueryPictIndexValuesRequest {
+    const OPCODE: u8 = 2;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = QueryPictIndexValuesReply;
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryPictIndexValuesReply {
+    pub reply_type: u8,
+    pub sequence: u16,
+    pub length: u32,
+    pub values: Vec<Indexvalue>,
+}
+impl QueryPictIndexValuesReply {}
+impl AsByteSequence for QueryPictIndexValuesReply {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.reply_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += (self.values.len() as Card32).as_bytes(&mut bytes[index..]);
+        index += 20;
+        let block_len: usize = vector_as_bytes(&self.values, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Indexvalue>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryPictIndexValuesReply from byte buffer");
+        let (reply_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u32, usize) = <u32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (len0, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 20;
+        let (values, block_len): (Vec<Indexvalue>, usize) =
+            vector_from_bytes(&bytes[index..], len0 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Indexvalue>());
+        Some((
+            QueryPictIndexValuesReply {
+                reply_type: reply_type,
+                sequence: sequence,
+                length: length,
+                values: values,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.reply_type.size()
+            + 1
+            + self.sequence.size()
+            + self.length.size()
+            + ::core::mem::size_of::<Card32>()
+            + 20
+            + {
+                let block_len: usize = self.values.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Indexvalue>());
+                block_len + pad
+            }
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreatePictureRequest {
+    pub req_type: u8,
+    pub pid: Picture,
+    pub length: u16,
+    pub drawable: Drawable,
+    pub format: Pictformat,
+    pub value_mask: Cp,
+    pub repeat: Repeat,
+    pub alphamap: Picture,
+    pub alphaxorigin: Int32,
+    pub alphayorigin: Int32,
+    pub clipxorigin: Int32,
+    pub clipyorigin: Int32,
+    pub clipmask: Pixmap,
+    pub graphicsexposure: Card32,
+    pub subwindowmode: SubwindowMode,
+    pub polyedge: PolyEdge,
+    pub polymode: PolyMode,
+    pub dither: Atom,
+    pub componentalpha: Card32,
+}
+impl CreatePictureRequest {}
+impl AsByteSequence for CreatePictureRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.pid.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.drawable.as_bytes(&mut bytes[index..]);
+        index += self.format.as_bytes(&mut bytes[index..]);
+        index += self.value_mask.as_bytes(&mut bytes[index..]);
+        let cond0 = (self.value_mask);
+        if cond0.repeat() {
+            index += self.repeat.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.alpha_map() {
+            index += self.alphamap.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.alpha_x_origin() {
+            index += self.alphaxorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.alpha_y_origin() {
+            index += self.alphayorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.clip_x_origin() {
+            index += self.clipxorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.clip_y_origin() {
+            index += self.clipyorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.clip_mask() {
+            index += self.clipmask.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.graphics_exposure() {
+            index += self.graphicsexposure.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.subwindow_mode() {
+            index += self.subwindowmode.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.poly_edge() {
+            index += self.polyedge.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.poly_mode() {
+            index += self.polymode.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.dither() {
+            index += self.dither.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.component_alpha() {
+            index += self.componentalpha.as_bytes(&mut bytes[index..]);
+        }
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreatePictureRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (pid, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (drawable, sz): (Drawable, usize) = <Drawable>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (value_mask, sz): (Cp, usize) = <Cp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let cond0 = (value_mask);
+        let repeat: Repeat = if cond0.repeat() {
+            let (repeat, sz): (Repeat, usize) = <Repeat>::from_bytes(&bytes[index..])?;
+            index += sz;
+            repeat
+        } else {
+            Default::default()
+        };
+        let alphamap: Picture = if cond0.alpha_map() {
+            let (alphamap, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+            index += sz;
+            alphamap
+        } else {
+            Default::default()
+        };
+        let alphaxorigin: Int32 = if cond0.alpha_x_origin() {
+            let (alphaxorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            alphaxorigin
+        } else {
+            Default::default()
+        };
+        let alphayorigin: Int32 = if cond0.alpha_y_origin() {
+            let (alphayorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            alphayorigin
+        } else {
+            Default::default()
+        };
+        let clipxorigin: Int32 = if cond0.clip_x_origin() {
+            let (clipxorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            clipxorigin
+        } else {
+            Default::default()
+        };
+        let clipyorigin: Int32 = if cond0.clip_y_origin() {
+            let (clipyorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            clipyorigin
+        } else {
+            Default::default()
+        };
+        let clipmask: Pixmap = if cond0.clip_mask() {
+            let (clipmask, sz): (Pixmap, usize) = <Pixmap>::from_bytes(&bytes[index..])?;
+            index += sz;
+            clipmask
+        } else {
+            Default::default()
+        };
+        let graphicsexposure: Card32 = if cond0.graphics_exposure() {
+            let (graphicsexposure, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            graphicsexposure
+        } else {
+            Default::default()
+        };
+        let subwindowmode: SubwindowMode = if cond0.subwindow_mode() {
+            let (subwindowmode, sz): (SubwindowMode, usize) =
+                <SubwindowMode>::from_bytes(&bytes[index..])?;
+            index += sz;
+            subwindowmode
+        } else {
+            Default::default()
+        };
+        let polyedge: PolyEdge = if cond0.poly_edge() {
+            let (polyedge, sz): (PolyEdge, usize) = <PolyEdge>::from_bytes(&bytes[index..])?;
+            index += sz;
+            polyedge
+        } else {
+            Default::default()
+        };
+        let polymode: PolyMode = if cond0.poly_mode() {
+            let (polymode, sz): (PolyMode, usize) = <PolyMode>::from_bytes(&bytes[index..])?;
+            index += sz;
+            polymode
+        } else {
+            Default::default()
+        };
+        let dither: Atom = if cond0.dither() {
+            let (dither, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
+            index += sz;
+            dither
+        } else {
+            Default::default()
+        };
+        let componentalpha: Card32 = if cond0.component_alpha() {
+            let (componentalpha, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            componentalpha
+        } else {
+            Default::default()
+        };
+        Some((
+            CreatePictureRequest {
+                req_type: req_type,
+                pid: pid,
+                length: length,
+                drawable: drawable,
+                format: format,
+                value_mask: value_mask,
+                repeat: repeat,
+                alphamap: alphamap,
+                alphaxorigin: alphaxorigin,
+                alphayorigin: alphayorigin,
+                clipxorigin: clipxorigin,
+                clipyorigin: clipyorigin,
+                clipmask: clipmask,
+                graphicsexposure: graphicsexposure,
+                subwindowmode: subwindowmode,
+                polyedge: polyedge,
+                polymode: polymode,
+                dither: dither,
+                componentalpha: componentalpha,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.pid.size()
+            + self.length.size()
+            + self.drawable.size()
+            + self.format.size()
+            + self.value_mask.size()
+            + self.repeat.size()
+            + self.alphamap.size()
+            + self.alphaxorigin.size()
+            + self.alphayorigin.size()
+            + self.clipxorigin.size()
+            + self.clipyorigin.size()
+            + self.clipmask.size()
+            + self.graphicsexposure.size()
+            + self.subwindowmode.size()
+            + self.polyedge.size()
+            + self.polymode.size()
+            + self.dither.size()
+            + self.componentalpha.size()
+    }
+}
+impl Request for CreatePictureRequest {
+    const OPCODE: u8 = 4;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Cp {
+    pub inner: u32,
+}
+impl Cp {
+    #[inline]
+    pub fn repeat(&self) -> bool {
+        self.inner & (1 << 0) != 0
+    }
+    #[inline]
+    pub fn set_repeat(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 0;
+        } else {
+            self.inner &= !(1 << 0);
+        }
+        self
+    }
+    #[inline]
+    pub fn alpha_map(&self) -> bool {
+        self.inner & (1 << 1) != 0
+    }
+    #[inline]
+    pub fn set_alpha_map(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 1;
+        } else {
+            self.inner &= !(1 << 1);
+        }
+        self
+    }
+    #[inline]
+    pub fn alpha_x_origin(&self) -> bool {
+        self.inner & (1 << 2) != 0
+    }
+    #[inline]
+    pub fn set_alpha_x_origin(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 2;
+        } else {
+            self.inner &= !(1 << 2);
+        }
+        self
+    }
+    #[inline]
+    pub fn alpha_y_origin(&self) -> bool {
+        self.inner & (1 << 3) != 0
+    }
+    #[inline]
+    pub fn set_alpha_y_origin(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 3;
+        } else {
+            self.inner &= !(1 << 3);
+        }
+        self
+    }
+    #[inline]
+    pub fn clip_x_origin(&self) -> bool {
+        self.inner & (1 << 4) != 0
+    }
+    #[inline]
+    pub fn set_clip_x_origin(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 4;
+        } else {
+            self.inner &= !(1 << 4);
+        }
+        self
+    }
+    #[inline]
+    pub fn clip_y_origin(&self) -> bool {
+        self.inner & (1 << 5) != 0
+    }
+    #[inline]
+    pub fn set_clip_y_origin(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 5;
+        } else {
+            self.inner &= !(1 << 5);
+        }
+        self
+    }
+    #[inline]
+    pub fn clip_mask(&self) -> bool {
+        self.inner & (1 << 6) != 0
+    }
+    #[inline]
+    pub fn set_clip_mask(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 6;
+        } else {
+            self.inner &= !(1 << 6);
+        }
+        self
+    }
+    #[inline]
+    pub fn graphics_exposure(&self) -> bool {
+        self.inner & (1 << 7) != 0
+    }
+    #[inline]
+    pub fn set_graphics_exposure(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 7;
+        } else {
+            self.inner &= !(1 << 7);
+        }
+        self
+    }
+    #[inline]
+    pub fn subwindow_mode(&self) -> bool {
+        self.inner & (1 << 8) != 0
+    }
+    #[inline]
+    pub fn set_subwindow_mode(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 8;
+        } else {
+            self.inner &= !(1 << 8);
+        }
+        self
+    }
+    #[inline]
+    pub fn poly_edge(&self) -> bool {
+        self.inner & (1 << 9) != 0
+    }
+    #[inline]
+    pub fn set_poly_edge(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 9;
+        } else {
+            self.inner &= !(1 << 9);
+        }
+        self
+    }
+    #[inline]
+    pub fn poly_mode(&self) -> bool {
+        self.inner & (1 << 10) != 0
+    }
+    #[inline]
+    pub fn set_poly_mode(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 10;
+        } else {
+            self.inner &= !(1 << 10);
+        }
+        self
+    }
+    #[inline]
+    pub fn dither(&self) -> bool {
+        self.inner & (1 << 11) != 0
+    }
+    #[inline]
+    pub fn set_dither(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 11;
+        } else {
+            self.inner &= !(1 << 11);
+        }
+        self
+    }
+    #[inline]
+    pub fn component_alpha(&self) -> bool {
+        self.inner & (1 << 12) != 0
+    }
+    #[inline]
+    pub fn set_component_alpha(&mut self, val: bool) -> &mut Self {
+        if val {
+            self.inner |= 1 << 12;
+        } else {
+            self.inner &= !(1 << 12);
+        }
+        self
+    }
+    #[inline]
+    pub fn new(
+        repeat: bool,
+        alpha_map: bool,
+        alpha_x_origin: bool,
+        alpha_y_origin: bool,
+        clip_x_origin: bool,
+        clip_y_origin: bool,
+        clip_mask: bool,
+        graphics_exposure: bool,
+        subwindow_mode: bool,
+        poly_edge: bool,
+        poly_mode: bool,
+        dither: bool,
+        component_alpha: bool,
+    ) -> Self {
+        let mut inner: u32 = 0;
+        if repeat {
+            inner |= 1 << 0;
+        } else {
+            inner &= !(1 << 0);
+        }
+        if alpha_map {
+            inner |= 1 << 1;
+        } else {
+            inner &= !(1 << 1);
+        }
+        if alpha_x_origin {
+            inner |= 1 << 2;
+        } else {
+            inner &= !(1 << 2);
+        }
+        if alpha_y_origin {
+            inner |= 1 << 3;
+        } else {
+            inner &= !(1 << 3);
+        }
+        if clip_x_origin {
+            inner |= 1 << 4;
+        } else {
+            inner &= !(1 << 4);
+        }
+        if clip_y_origin {
+            inner |= 1 << 5;
+        } else {
+            inner &= !(1 << 5);
+        }
+        if clip_mask {
+            inner |= 1 << 6;
+        } else {
+            inner &= !(1 << 6);
+        }
+        if graphics_exposure {
+            inner |= 1 << 7;
+        } else {
+            inner &= !(1 << 7);
+        }
+        if subwindow_mode {
+            inner |= 1 << 8;
+        } else {
+            inner &= !(1 << 8);
+        }
+        if poly_edge {
+            inner |= 1 << 9;
+        } else {
+            inner &= !(1 << 9);
+        }
+        if poly_mode {
+            inner |= 1 << 10;
+        } else {
+            inner &= !(1 << 10);
+        }
+        if dither {
+            inner |= 1 << 11;
+        } else {
+            inner &= !(1 << 11);
+        }
+        if component_alpha {
+            inner |= 1 << 12;
+        } else {
+            inner &= !(1 << 12);
+        }
+        Cp { inner: inner }
+    }
+}
+impl AsByteSequence for Cp {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        self.inner.as_bytes(bytes)
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let (inner, sz): (u32, usize) = <u32>::from_bytes(bytes)?;
+        Some((Cp { inner: inner }, sz))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct ChangePictureRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub value_mask: Cp,
+    pub repeat: Repeat,
+    pub alphamap: Picture,
+    pub alphaxorigin: Int32,
+    pub alphayorigin: Int32,
+    pub clipxorigin: Int32,
+    pub clipyorigin: Int32,
+    pub clipmask: Pixmap,
+    pub graphicsexposure: Card32,
+    pub subwindowmode: SubwindowMode,
+    pub polyedge: PolyEdge,
+    pub polymode: PolyMode,
+    pub dither: Atom,
+    pub componentalpha: Card32,
+}
+impl ChangePictureRequest {}
+impl AsByteSequence for ChangePictureRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.value_mask.as_bytes(&mut bytes[index..]);
+        let cond0 = (self.value_mask);
+        if cond0.repeat() {
+            index += self.repeat.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.alpha_map() {
+            index += self.alphamap.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.alpha_x_origin() {
+            index += self.alphaxorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.alpha_y_origin() {
+            index += self.alphayorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.clip_x_origin() {
+            index += self.clipxorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.clip_y_origin() {
+            index += self.clipyorigin.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.clip_mask() {
+            index += self.clipmask.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.graphics_exposure() {
+            index += self.graphicsexposure.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.subwindow_mode() {
+            index += self.subwindowmode.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.poly_edge() {
+            index += self.polyedge.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.poly_mode() {
+            index += self.polymode.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.dither() {
+            index += self.dither.as_bytes(&mut bytes[index..]);
+        }
+        if cond0.component_alpha() {
+            index += self.componentalpha.as_bytes(&mut bytes[index..]);
+        }
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ChangePictureRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (value_mask, sz): (Cp, usize) = <Cp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let cond0 = (value_mask);
+        let repeat: Repeat = if cond0.repeat() {
+            let (repeat, sz): (Repeat, usize) = <Repeat>::from_bytes(&bytes[index..])?;
+            index += sz;
+            repeat
+        } else {
+            Default::default()
+        };
+        let alphamap: Picture = if cond0.alpha_map() {
+            let (alphamap, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+            index += sz;
+            alphamap
+        } else {
+            Default::default()
+        };
+        let alphaxorigin: Int32 = if cond0.alpha_x_origin() {
+            let (alphaxorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            alphaxorigin
+        } else {
+            Default::default()
+        };
+        let alphayorigin: Int32 = if cond0.alpha_y_origin() {
+            let (alphayorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            alphayorigin
+        } else {
+            Default::default()
+        };
+        let clipxorigin: Int32 = if cond0.clip_x_origin() {
+            let (clipxorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            clipxorigin
+        } else {
+            Default::default()
+        };
+        let clipyorigin: Int32 = if cond0.clip_y_origin() {
+            let (clipyorigin, sz): (Int32, usize) = <Int32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            clipyorigin
+        } else {
+            Default::default()
+        };
+        let clipmask: Pixmap = if cond0.clip_mask() {
+            let (clipmask, sz): (Pixmap, usize) = <Pixmap>::from_bytes(&bytes[index..])?;
+            index += sz;
+            clipmask
+        } else {
+            Default::default()
+        };
+        let graphicsexposure: Card32 = if cond0.graphics_exposure() {
+            let (graphicsexposure, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            graphicsexposure
+        } else {
+            Default::default()
+        };
+        let subwindowmode: SubwindowMode = if cond0.subwindow_mode() {
+            let (subwindowmode, sz): (SubwindowMode, usize) =
+                <SubwindowMode>::from_bytes(&bytes[index..])?;
+            index += sz;
+            subwindowmode
+        } else {
+            Default::default()
+        };
+        let polyedge: PolyEdge = if cond0.poly_edge() {
+            let (polyedge, sz): (PolyEdge, usize) = <PolyEdge>::from_bytes(&bytes[index..])?;
+            index += sz;
+            polyedge
+        } else {
+            Default::default()
+        };
+        let polymode: PolyMode = if cond0.poly_mode() {
+            let (polymode, sz): (PolyMode, usize) = <PolyMode>::from_bytes(&bytes[index..])?;
+            index += sz;
+            polymode
+        } else {
+            Default::default()
+        };
+        let dither: Atom = if cond0.dither() {
+            let (dither, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
+            index += sz;
+            dither
+        } else {
+            Default::default()
+        };
+        let componentalpha: Card32 = if cond0.component_alpha() {
+            let (componentalpha, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+            index += sz;
+            componentalpha
+        } else {
+            Default::default()
+        };
+        Some((
+            ChangePictureRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                value_mask: value_mask,
+                repeat: repeat,
+                alphamap: alphamap,
+                alphaxorigin: alphaxorigin,
+                alphayorigin: alphayorigin,
+                clipxorigin: clipxorigin,
+                clipyorigin: clipyorigin,
+                clipmask: clipmask,
+                graphicsexposure: graphicsexposure,
+                subwindowmode: subwindowmode,
+                polyedge: polyedge,
+                polymode: polymode,
+                dither: dither,
+                componentalpha: componentalpha,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.picture.size()
+            + self.length.size()
+            + self.value_mask.size()
+            + self.repeat.size()
+            + self.alphamap.size()
+            + self.alphaxorigin.size()
+            + self.alphayorigin.size()
+            + self.clipxorigin.size()
+            + self.clipyorigin.size()
+            + self.clipmask.size()
+            + self.graphicsexposure.size()
+            + self.subwindowmode.size()
+            + self.polyedge.size()
+            + self.polymode.size()
+            + self.dither.size()
+            + self.componentalpha.size()
+    }
+}
+impl Request for ChangePictureRequest {
+    const OPCODE: u8 = 5;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct SetPictureClipRectanglesRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub clip_x_origin: Int16,
+    pub clip_y_origin: Int16,
+    pub rectangles: Vec<Rectangle>,
+}
+impl SetPictureClipRectanglesRequest {}
+impl AsByteSequence for SetPictureClipRectanglesRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.clip_x_origin.as_bytes(&mut bytes[index..]);
+        index += self.clip_y_origin.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.rectangles, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Rectangle>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing SetPictureClipRectanglesRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (clip_x_origin, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (clip_y_origin, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (rectangles, block_len): (Vec<Rectangle>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Rectangle>());
+        Some((
+            SetPictureClipRectanglesRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                clip_x_origin: clip_x_origin,
+                clip_y_origin: clip_y_origin,
+                rectangles: rectangles,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.picture.size()
+            + self.length.size()
+            + self.clip_x_origin.size()
+            + self.clip_y_origin.size()
+            + {
+                let block_len: usize = self.rectangles.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Rectangle>());
+                block_len + pad
+            }
+    }
+}
+impl Request for SetPictureClipRectanglesRequest {
+    const OPCODE: u8 = 6;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct FreePictureRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+}
+impl FreePictureRequest {}
+impl AsByteSequence for FreePictureRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing FreePictureRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            FreePictureRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.picture.size() + self.length.size()
+    }
+}
+impl Request for FreePictureRequest {
+    const OPCODE: u8 = 7;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CompositeRequest {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub mask: Picture,
+    pub dst: Picture,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub mask_x: Int16,
+    pub mask_y: Int16,
+    pub dst_x: Int16,
+    pub dst_y: Int16,
+    pub width: Card16,
+    pub height: Card16,
+}
+impl CompositeRequest {}
+impl AsByteSequence for CompositeRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.mask.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        index += self.mask_x.as_bytes(&mut bytes[index..]);
+        index += self.mask_y.as_bytes(&mut bytes[index..]);
+        index += self.dst_x.as_bytes(&mut bytes[index..]);
+        index += self.dst_y.as_bytes(&mut bytes[index..]);
+        index += self.width.as_bytes(&mut bytes[index..]);
+        index += self.height.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CompositeRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            CompositeRequest {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                mask: mask,
+                dst: dst,
+                src_x: src_x,
+                src_y: src_y,
+                mask_x: mask_x,
+                mask_y: mask_y,
+                dst_x: dst_x,
+                dst_y: dst_y,
+                width: width,
+                height: height,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.mask.size()
+            + self.dst.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + self.mask_x.size()
+            + self.mask_y.size()
+            + self.dst_x.size()
+            + self.dst_y.size()
+            + self.width.size()
+            + self.height.size()
+    }
+}
+impl Request for CompositeRequest {
+    const OPCODE: u8 = 8;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PictOp {
+    Clear = 0,
+    Src = 1,
+    Dst = 2,
+    Over = 3,
+    OverReverse = 4,
+    In = 5,
+    InReverse = 6,
+    Out = 7,
+    OutReverse = 8,
+    Atop = 9,
+    AtopReverse = 10,
+    Xor = 11,
+    Add = 12,
+    Saturate = 13,
+    DisjointClear = 16,
+    DisjointSrc = 17,
+    DisjointDst = 18,
+    DisjointOver = 19,
+    DisjointOverReverse = 20,
+    DisjointIn = 21,
+    DisjointInReverse = 22,
+    DisjointOut = 23,
+    DisjointOutReverse = 24,
+    DisjointAtop = 25,
+    DisjointAtopReverse = 26,
+    DisjointXor = 27,
+    ConjointClear = 32,
+    ConjointSrc = 33,
+    ConjointDst = 34,
+    ConjointOver = 35,
+    ConjointOverReverse = 36,
+    ConjointIn = 37,
+    ConjointInReverse = 38,
+    ConjointOut = 39,
+    ConjointOutReverse = 40,
+    ConjointAtop = 41,
+    ConjointAtopReverse = 42,
+    ConjointXor = 43,
+    Multiply = 48,
+    Screen = 49,
+    Overlay = 50,
+    Darken = 51,
+    Lighten = 52,
+    ColorDodge = 53,
+    ColorBurn = 54,
+    HardLight = 55,
+    SoftLight = 56,
+    Difference = 57,
+    Exclusion = 58,
+    HslHue = 59,
+    HslSaturation = 60,
+    HslColor = 61,
+    HslLuminosity = 62,
+}
+impl AsByteSequence for PictOp {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        (*self as u8).as_bytes(bytes)
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let (underlying, sz): (u8, usize) = <u8>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Clear, sz)),
+            1 => Some((Self::Src, sz)),
+            2 => Some((Self::Dst, sz)),
+            3 => Some((Self::Over, sz)),
+            4 => Some((Self::OverReverse, sz)),
+            5 => Some((Self::In, sz)),
+            6 => Some((Self::InReverse, sz)),
+            7 => Some((Self::Out, sz)),
+            8 => Some((Self::OutReverse, sz)),
+            9 => Some((Self::Atop, sz)),
+            10 => Some((Self::AtopReverse, sz)),
+            11 => Some((Self::Xor, sz)),
+            12 => Some((Self::Add, sz)),
+            13 => Some((Self::Saturate, sz)),
+            16 => Some((Self::DisjointClear, sz)),
+            17 => Some((Self::DisjointSrc, sz)),
+            18 => Some((Self::DisjointDst, sz)),
+            19 => Some((Self::DisjointOver, sz)),
+            20 => Some((Self::DisjointOverReverse, sz)),
+            21 => Some((Self::DisjointIn, sz)),
+            22 => Some((Self::DisjointInReverse, sz)),
+            23 => Some((Self::DisjointOut, sz)),
+            24 => Some((Self::DisjointOutReverse, sz)),
+            25 => Some((Self::DisjointAtop, sz)),
+            26 => Some((Self::DisjointAtopReverse, sz)),
+            27 => Some((Self::DisjointXor, sz)),
+            32 => Some((Self::ConjointClear, sz)),
+            33 => Some((Self::ConjointSrc, sz)),
+            34 => Some((Self::ConjointDst, sz)),
+            35 => Some((Self::ConjointOver, sz)),
+            36 => Some((Self::ConjointOverReverse, sz)),
+            37 => Some((Self::ConjointIn, sz)),
+            38 => Some((Self::ConjointInReverse, sz)),
+            39 => Some((Self::ConjointOut, sz)),
+            40 => Some((Self::ConjointOutReverse, sz)),
+            41 => Some((Self::ConjointAtop, sz)),
+            42 => Some((Self::ConjointAtopReverse, sz)),
+            43 => Some((Self::ConjointXor, sz)),
+            48 => Some((Self::Multiply, sz)),
+            49 => Some((Self::Screen, sz)),
+            50 => Some((Self::Overlay, sz)),
+            51 => Some((Self::Darken, sz)),
+            52 => Some((Self::Lighten, sz)),
+            53 => Some((Self::ColorDodge, sz)),
+            54 => Some((Self::ColorBurn, sz)),
+            55 => Some((Self::HardLight, sz)),
+            56 => Some((Self::SoftLight, sz)),
+            57 => Some((Self::Difference, sz)),
+            58 => Some((Self::Exclusion, sz)),
+            59 => Some((Self::HslHue, sz)),
+            60 => Some((Self::HslSaturation, sz)),
+            61 => Some((Self::HslColor, sz)),
+            62 => Some((Self::HslLuminosity, sz)),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        ::core::mem::size_of::<u8>()
+    }
+}
+impl Default for PictOp {
+    #[inline]
+    fn default() -> PictOp {
+        PictOp::Clear
+    }
+}
+pub const PICTURE_NONE: Picture = <Picture>::const_from_xid(0);
+#[derive(Clone, Debug, Default)]
+pub struct TrapezoidsRequest {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub traps: Vec<Trapezoid>,
+}
+impl TrapezoidsRequest {}
+impl AsByteSequence for TrapezoidsRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.mask_format.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.traps, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Trapezoid>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing TrapezoidsRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (traps, block_len): (Vec<Trapezoid>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Trapezoid>());
+        Some((
+            TrapezoidsRequest {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                dst: dst,
+                mask_format: mask_format,
+                src_x: src_x,
+                src_y: src_y,
+                traps: traps,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.dst.size()
+            + self.mask_format.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + {
+                let block_len: usize = self.traps.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Trapezoid>());
+                block_len + pad
+            }
+    }
+}
+impl Request for TrapezoidsRequest {
+    const OPCODE: u8 = 10;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct TrianglesRequest {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub triangles: Vec<Triangle>,
+}
+impl TrianglesRequest {}
+impl AsByteSequence for TrianglesRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.mask_format.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.triangles, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Triangle>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing TrianglesRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (triangles, block_len): (Vec<Triangle>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Triangle>());
+        Some((
+            TrianglesRequest {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                dst: dst,
+                mask_format: mask_format,
+                src_x: src_x,
+                src_y: src_y,
+                triangles: triangles,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.dst.size()
+            + self.mask_format.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + {
+                let block_len: usize = self.triangles.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Triangle>());
+                block_len + pad
+            }
+    }
+}
+impl Request for TrianglesRequest {
+    const OPCODE: u8 = 11;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct TriStripRequest {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub points: Vec<Pointfix>,
+}
+impl TriStripRequest {}
+impl AsByteSequence for TriStripRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.mask_format.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.points, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pointfix>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing TriStripRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (points, block_len): (Vec<Pointfix>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pointfix>());
+        Some((
+            TriStripRequest {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                dst: dst,
+                mask_format: mask_format,
+                src_x: src_x,
+                src_y: src_y,
+                points: points,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.dst.size()
+            + self.mask_format.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + {
+                let block_len: usize = self.points.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Pointfix>());
+                block_len + pad
+            }
+    }
+}
+impl Request for TriStripRequest {
+    const OPCODE: u8 = 12;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct TriFanRequest {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub points: Vec<Pointfix>,
+}
+impl TriFanRequest {}
+impl AsByteSequence for TriFanRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.mask_format.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.points, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pointfix>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing TriFanRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (points, block_len): (Vec<Pointfix>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Pointfix>());
+        Some((
+            TriFanRequest {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                dst: dst,
+                mask_format: mask_format,
+                src_x: src_x,
+                src_y: src_y,
+                points: points,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.dst.size()
+            + self.mask_format.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + {
+                let block_len: usize = self.points.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Pointfix>());
+                block_len + pad
+            }
+    }
+}
+impl Request for TriFanRequest {
+    const OPCODE: u8 = 13;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateGlyphSetRequest {
+    pub req_type: u8,
+    pub gsid: Glyphset,
+    pub length: u16,
+    pub format: Pictformat,
+}
+impl CreateGlyphSetRequest {}
+impl AsByteSequence for CreateGlyphSetRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.gsid.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.format.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateGlyphSetRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (gsid, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            CreateGlyphSetRequest {
+                req_type: req_type,
+                gsid: gsid,
+                length: length,
+                format: format,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.gsid.size() + self.length.size() + self.format.size()
+    }
+}
+impl Request for CreateGlyphSetRequest {
+    const OPCODE: u8 = 17;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct ReferenceGlyphSetRequest {
+    pub req_type: u8,
+    pub gsid: Glyphset,
+    pub length: u16,
+    pub existing: Glyphset,
+}
+impl ReferenceGlyphSetRequest {}
+impl AsByteSequence for ReferenceGlyphSetRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.gsid.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.existing.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ReferenceGlyphSetRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (gsid, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (existing, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            ReferenceGlyphSetRequest {
+                req_type: req_type,
+                gsid: gsid,
+                length: length,
+                existing: existing,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.gsid.size() + self.length.size() + self.existing.size()
+    }
+}
+impl Request for ReferenceGlyphSetRequest {
+    const OPCODE: u8 = 18;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct FreeGlyphSetRequest {
+    pub req_type: u8,
+    pub glyphset: Glyphset,
+    pub length: u16,
+}
+impl FreeGlyphSetRequest {}
+impl AsByteSequence for FreeGlyphSetRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.glyphset.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing FreeGlyphSetRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphset, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            FreeGlyphSetRequest {
+                req_type: req_type,
+                glyphset: glyphset,
+                length: length,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.glyphset.size() + self.length.size()
+    }
+}
+impl Request for FreeGlyphSetRequest {
+    const OPCODE: u8 = 19;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct AddGlyphsRequest {
+    pub req_type: u8,
+    pub glyphset: Glyphset,
+    pub length: u16,
+    pub glyphs_len: Card32,
+    pub glyphids: Vec<Card32>,
+    pub glyphs: Vec<Glyphinfo>,
+    pub data: Vec<Byte>,
+}
+impl AddGlyphsRequest {}
+impl AsByteSequence for AddGlyphsRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.glyphset.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.glyphs_len.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.glyphids, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Card32>());
+        let block_len: usize = vector_as_bytes(&self.glyphs, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Glyphinfo>());
+        let block_len: usize = vector_as_bytes(&self.data, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing AddGlyphsRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphset, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphs_len, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphids, block_len): (Vec<Card32>, usize) =
+            vector_from_bytes(&bytes[index..], (glyphs_len as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Card32>());
+        let (glyphs, block_len): (Vec<Glyphinfo>, usize) =
+            vector_from_bytes(&bytes[index..], (glyphs_len as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Glyphinfo>());
+        let (data, block_len): (Vec<Byte>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        Some((
+            AddGlyphsRequest {
+                req_type: req_type,
+                glyphset: glyphset,
+                length: length,
+                glyphs_len: glyphs_len,
+                glyphids: glyphids,
+                glyphs: glyphs,
+                data: data,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.glyphset.size()
+            + self.length.size()
+            + self.glyphs_len.size()
+            + {
+                let block_len: usize = self.glyphids.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Card32>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.glyphs.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Glyphinfo>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.data.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+                block_len + pad
+            }
+    }
+}
+impl Request for AddGlyphsRequest {
+    const OPCODE: u8 = 20;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct FreeGlyphsRequest {
+    pub req_type: u8,
+    pub glyphset: Glyphset,
+    pub length: u16,
+    pub glyphs: Vec<Glyph>,
+}
+impl FreeGlyphsRequest {}
+impl AsByteSequence for FreeGlyphsRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.glyphset.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.glyphs, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Glyph>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing FreeGlyphsRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphset, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphs, block_len): (Vec<Glyph>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Glyph>());
+        Some((
+            FreeGlyphsRequest {
+                req_type: req_type,
+                glyphset: glyphset,
+                length: length,
+                glyphs: glyphs,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.glyphset.size() + self.length.size() + {
+            let block_len: usize = self.glyphs.iter().map(|i| i.size()).sum();
+            let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Glyph>());
+            block_len + pad
+        }
+    }
+}
+impl Request for FreeGlyphsRequest {
+    const OPCODE: u8 = 22;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CompositeGlyphs8Request {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub glyphset: Glyphset,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub glyphcmds: Vec<Byte>,
+}
+impl CompositeGlyphs8Request {}
+impl AsByteSequence for CompositeGlyphs8Request {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.mask_format.as_bytes(&mut bytes[index..]);
+        index += self.glyphset.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.glyphcmds, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CompositeGlyphs8Request from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphset, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphcmds, block_len): (Vec<Byte>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        Some((
+            CompositeGlyphs8Request {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                dst: dst,
+                mask_format: mask_format,
+                glyphset: glyphset,
+                src_x: src_x,
+                src_y: src_y,
+                glyphcmds: glyphcmds,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.dst.size()
+            + self.mask_format.size()
+            + self.glyphset.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + {
+                let block_len: usize = self.glyphcmds.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+                block_len + pad
+            }
+    }
+}
+impl Request for CompositeGlyphs8Request {
+    const OPCODE: u8 = 23;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CompositeGlyphs16Request {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub glyphset: Glyphset,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub glyphcmds: Vec<Byte>,
+}
+impl CompositeGlyphs16Request {}
+impl AsByteSequence for CompositeGlyphs16Request {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.mask_format.as_bytes(&mut bytes[index..]);
+        index += self.glyphset.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.glyphcmds, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CompositeGlyphs16Request from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphset, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphcmds, block_len): (Vec<Byte>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        Some((
+            CompositeGlyphs16Request {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                dst: dst,
+                mask_format: mask_format,
+                glyphset: glyphset,
+                src_x: src_x,
+                src_y: src_y,
+                glyphcmds: glyphcmds,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.dst.size()
+            + self.mask_format.size()
+            + self.glyphset.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + {
+                let block_len: usize = self.glyphcmds.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+                block_len + pad
+            }
+    }
+}
+impl Request for CompositeGlyphs16Request {
+    const OPCODE: u8 = 24;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CompositeGlyphs32Request {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub src: Picture,
+    pub dst: Picture,
+    pub mask_format: Pictformat,
+    pub glyphset: Glyphset,
+    pub src_x: Int16,
+    pub src_y: Int16,
+    pub glyphcmds: Vec<Byte>,
+}
+impl CompositeGlyphs32Request {}
+impl AsByteSequence for CompositeGlyphs32Request {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.src.as_bytes(&mut bytes[index..]);
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.mask_format.as_bytes(&mut bytes[index..]);
+        index += self.glyphset.as_bytes(&mut bytes[index..]);
+        index += self.src_x.as_bytes(&mut bytes[index..]);
+        index += self.src_y.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.glyphcmds, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CompositeGlyphs32Request from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (src, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mask_format, sz): (Pictformat, usize) = <Pictformat>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphset, sz): (Glyphset, usize) = <Glyphset>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (src_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (glyphcmds, block_len): (Vec<Byte>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+        Some((
+            CompositeGlyphs32Request {
+                req_type: req_type,
+                op: op,
+                length: length,
+                src: src,
+                dst: dst,
+                mask_format: mask_format,
+                glyphset: glyphset,
+                src_x: src_x,
+                src_y: src_y,
+                glyphcmds: glyphcmds,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.src.size()
+            + self.dst.size()
+            + self.mask_format.size()
+            + self.glyphset.size()
+            + self.src_x.size()
+            + self.src_y.size()
+            + {
+                let block_len: usize = self.glyphcmds.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Byte>());
+                block_len + pad
+            }
+    }
+}
+impl Request for CompositeGlyphs32Request {
+    const OPCODE: u8 = 25;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct FillRectanglesRequest {
+    pub req_type: u8,
+    pub op: PictOp,
+    pub length: u16,
+    pub dst: Picture,
+    pub color: Color,
+    pub rects: Vec<Rectangle>,
+}
+impl FillRectanglesRequest {}
+impl AsByteSequence for FillRectanglesRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.op.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index += self.dst.as_bytes(&mut bytes[index..]);
+        index += self.color.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.rects, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Rectangle>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing FillRectanglesRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (op, sz): (PictOp, usize) = <PictOp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        let (dst, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (color, sz): (Color, usize) = <Color>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (rects, block_len): (Vec<Rectangle>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Rectangle>());
+        Some((
+            FillRectanglesRequest {
+                req_type: req_type,
+                op: op,
+                length: length,
+                dst: dst,
+                color: color,
+                rects: rects,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.op.size()
+            + self.length.size()
+            + 3
+            + self.dst.size()
+            + self.color.size()
+            + {
+                let block_len: usize = self.rects.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Rectangle>());
+                block_len + pad
+            }
+    }
+}
+impl Request for FillRectanglesRequest {
+    const OPCODE: u8 = 26;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateCursorRequest {
+    pub req_type: u8,
+    pub cid: Cursor,
+    pub length: u16,
+    pub source: Picture,
+    pub x: Card16,
+    pub y: Card16,
+}
+impl CreateCursorRequest {}
+impl AsByteSequence for CreateCursorRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.cid.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.source.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateCursorRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (cid, sz): (Cursor, usize) = <Cursor>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (source, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            CreateCursorRequest {
+                req_type: req_type,
+                cid: cid,
+                length: length,
+                source: source,
+                x: x,
+                y: y,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.cid.size()
+            + self.length.size()
+            + self.source.size()
+            + self.x.size()
+            + self.y.size()
+    }
+}
+impl Request for CreateCursorRequest {
+    const OPCODE: u8 = 27;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct Transform {
+    pub matrix11: Fixed,
+    pub matrix12: Fixed,
+    pub matrix13: Fixed,
+    pub matrix21: Fixed,
+    pub matrix22: Fixed,
+    pub matrix23: Fixed,
+    pub matrix31: Fixed,
+    pub matrix32: Fixed,
+    pub matrix33: Fixed,
+}
+impl Transform {}
+impl AsByteSequence for Transform {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.matrix11.as_bytes(&mut bytes[index..]);
+        index += self.matrix12.as_bytes(&mut bytes[index..]);
+        index += self.matrix13.as_bytes(&mut bytes[index..]);
+        index += self.matrix21.as_bytes(&mut bytes[index..]);
+        index += self.matrix22.as_bytes(&mut bytes[index..]);
+        index += self.matrix23.as_bytes(&mut bytes[index..]);
+        index += self.matrix31.as_bytes(&mut bytes[index..]);
+        index += self.matrix32.as_bytes(&mut bytes[index..]);
+        index += self.matrix33.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Transform from byte buffer");
+        let (matrix11, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix12, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix13, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix21, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix22, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix23, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix31, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix32, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (matrix33, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Transform {
+                matrix11: matrix11,
+                matrix12: matrix12,
+                matrix13: matrix13,
+                matrix21: matrix21,
+                matrix22: matrix22,
+                matrix23: matrix23,
+                matrix31: matrix31,
+                matrix32: matrix32,
+                matrix33: matrix33,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.matrix11.size()
+            + self.matrix12.size()
+            + self.matrix13.size()
+            + self.matrix21.size()
+            + self.matrix22.size()
+            + self.matrix23.size()
+            + self.matrix31.size()
+            + self.matrix32.size()
+            + self.matrix33.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct SetPictureTransformRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub transform: Transform,
+}
+impl SetPictureTransformRequest {}
+impl AsByteSequence for SetPictureTransformRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.transform.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing SetPictureTransformRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (transform, sz): (Transform, usize) = <Transform>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            SetPictureTransformRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                transform: transform,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.picture.size() + self.length.size() + self.transform.size()
+    }
+}
+impl Request for SetPictureTransformRequest {
+    const OPCODE: u8 = 28;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryFiltersRequest {
+    pub req_type: u8,
+    pub drawable: Drawable,
+    pub length: u16,
+}
+impl QueryFiltersRequest {}
+impl AsByteSequence for QueryFiltersRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.drawable.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryFiltersRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (drawable, sz): (Drawable, usize) = <Drawable>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            QueryFiltersRequest {
+                req_type: req_type,
+                drawable: drawable,
+                length: length,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.drawable.size() + self.length.size()
+    }
+}
+impl Request for QueryFiltersRequest {
+    const OPCODE: u8 = 29;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = QueryFiltersReply;
+}
+#[derive(Clone, Debug, Default)]
+pub struct QueryFiltersReply {
+    pub reply_type: u8,
+    pub sequence: u16,
+    pub length: u32,
+    pub aliases: Vec<Card16>,
+    pub filters: Vec<Str>,
+}
+impl QueryFiltersReply {}
+impl AsByteSequence for QueryFiltersReply {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.reply_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += (self.aliases.len() as Card32).as_bytes(&mut bytes[index..]);
+        index += (self.filters.len() as Card32).as_bytes(&mut bytes[index..]);
+        index += 16;
+        let block_len: usize = vector_as_bytes(&self.aliases, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Card16>());
+        let block_len: usize = vector_as_bytes(&self.filters, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Str>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing QueryFiltersReply from byte buffer");
+        let (reply_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u32, usize) = <u32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (len0, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (len1, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 16;
+        let (aliases, block_len): (Vec<Card16>, usize) =
+            vector_from_bytes(&bytes[index..], len0 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Card16>());
+        let (filters, block_len): (Vec<Str>, usize) =
+            vector_from_bytes(&bytes[index..], len1 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Str>());
+        Some((
+            QueryFiltersReply {
+                reply_type: reply_type,
+                sequence: sequence,
+                length: length,
+                aliases: aliases,
+                filters: filters,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.reply_type.size()
+            + 1
+            + self.sequence.size()
+            + self.length.size()
+            + ::core::mem::size_of::<Card32>()
+            + ::core::mem::size_of::<Card32>()
+            + 16
+            + {
+                let block_len: usize = self.aliases.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Card16>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.filters.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Str>());
+                block_len + pad
+            }
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct SetPictureFilterRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub filter: String,
+    pub values: Vec<Fixed>,
+}
+impl SetPictureFilterRequest {}
+impl AsByteSequence for SetPictureFilterRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += (self.filter.len() as Card16).as_bytes(&mut bytes[index..]);
+        index += 2;
+        let block_len: usize = string_as_bytes(&self.filter, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, 4);
+        let block_len: usize = vector_as_bytes(&self.values, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing SetPictureFilterRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (len0, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 2;
+        let (filter, block_len): (String, usize) =
+            string_from_bytes(&bytes[index..], len0 as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, 4);
+        let (values, block_len): (Vec<Fixed>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        Some((
+            SetPictureFilterRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                filter: filter,
+                values: values,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.picture.size()
+            + self.length.size()
+            + ::core::mem::size_of::<Card16>()
+            + 2
+            + {
+                let block_len: usize = self.filter.len();
+                let pad: usize = buffer_pad(block_len, 4);
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.values.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+                block_len + pad
+            }
+    }
+}
+impl Request for SetPictureFilterRequest {
+    const OPCODE: u8 = 30;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct Animcursorelt {
+    pub cursor: Cursor,
+    pub delay: Card32,
+}
+impl Animcursorelt {}
+impl AsByteSequence for Animcursorelt {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.cursor.as_bytes(&mut bytes[index..]);
+        index += self.delay.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Animcursorelt from byte buffer");
+        let (cursor, sz): (Cursor, usize) = <Cursor>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (delay, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            Animcursorelt {
+                cursor: cursor,
+                delay: delay,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.cursor.size() + self.delay.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateAnimCursorRequest {
+    pub req_type: u8,
+    pub cid: Cursor,
+    pub length: u16,
+    pub cursors: Vec<Animcursorelt>,
+}
+impl CreateAnimCursorRequest {}
+impl AsByteSequence for CreateAnimCursorRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.cid.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.cursors, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Animcursorelt>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateAnimCursorRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (cid, sz): (Cursor, usize) = <Cursor>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (cursors, block_len): (Vec<Animcursorelt>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Animcursorelt>());
+        Some((
+            CreateAnimCursorRequest {
+                req_type: req_type,
+                cid: cid,
+                length: length,
+                cursors: cursors,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.cid.size() + self.length.size() + {
+            let block_len: usize = self.cursors.iter().map(|i| i.size()).sum();
+            let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Animcursorelt>());
+            block_len + pad
+        }
+    }
+}
+impl Request for CreateAnimCursorRequest {
+    const OPCODE: u8 = 31;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct Spanfix {
+    pub l: Fixed,
+    pub r: Fixed,
+    pub y: Fixed,
+}
+impl Spanfix {}
+impl AsByteSequence for Spanfix {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.l.as_bytes(&mut bytes[index..]);
+        index += self.r.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Spanfix from byte buffer");
+        let (l, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (r, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((Spanfix { l: l, r: r, y: y }, index))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.l.size() + self.r.size() + self.y.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct Trap {
+    pub top: Spanfix,
+    pub bot: Spanfix,
+}
+impl Trap {}
+impl AsByteSequence for Trap {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.top.as_bytes(&mut bytes[index..]);
+        index += self.bot.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing Trap from byte buffer");
+        let (top, sz): (Spanfix, usize) = <Spanfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bot, sz): (Spanfix, usize) = <Spanfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((Trap { top: top, bot: bot }, index))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.top.size() + self.bot.size()
+    }
+}
+#[derive(Clone, Debug, Default)]
+pub struct AddTrapsRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub x_off: Int16,
+    pub y_off: Int16,
+    pub traps: Vec<Trap>,
+}
+impl AddTrapsRequest {}
+impl AsByteSequence for AddTrapsRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.x_off.as_bytes(&mut bytes[index..]);
+        index += self.y_off.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.traps, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Trap>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing AddTrapsRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x_off, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y_off, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (traps, block_len): (Vec<Trap>, usize) =
+            vector_from_bytes(&bytes[index..], ((length as usize * 4) - index) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Trap>());
+        Some((
+            AddTrapsRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                x_off: x_off,
+                y_off: y_off,
+                traps: traps,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.picture.size()
+            + self.length.size()
+            + self.x_off.size()
+            + self.y_off.size()
+            + {
+                let block_len: usize = self.traps.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Trap>());
+                block_len + pad
+            }
+    }
+}
+impl Request for AddTrapsRequest {
+    const OPCODE: u8 = 32;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateSolidFillRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub color: Color,
+}
+impl CreateSolidFillRequest {}
+impl AsByteSequence for CreateSolidFillRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.color.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateSolidFillRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (color, sz): (Color, usize) = <Color>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            CreateSolidFillRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                color: color,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size() + self.picture.size() + self.length.size() + self.color.size()
+    }
+}
+impl Request for CreateSolidFillRequest {
+    const OPCODE: u8 = 33;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateLinearGradientRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub p1: Pointfix,
+    pub p2: Pointfix,
+    pub num_stops: Card32,
+    pub stops: Vec<Fixed>,
+    pub colors: Vec<Color>,
+}
+impl CreateLinearGradientRequest {}
+impl AsByteSequence for CreateLinearGradientRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.p1.as_bytes(&mut bytes[index..]);
+        index += self.p2.as_bytes(&mut bytes[index..]);
+        index += self.num_stops.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.stops, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        let block_len: usize = vector_as_bytes(&self.colors, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Color>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateLinearGradientRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (p1, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (p2, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (num_stops, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (stops, block_len): (Vec<Fixed>, usize) =
+            vector_from_bytes(&bytes[index..], (num_stops as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        let (colors, block_len): (Vec<Color>, usize) =
+            vector_from_bytes(&bytes[index..], (num_stops as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Color>());
+        Some((
+            CreateLinearGradientRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                p1: p1,
+                p2: p2,
+                num_stops: num_stops,
+                stops: stops,
+                colors: colors,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.picture.size()
+            + self.length.size()
+            + self.p1.size()
+            + self.p2.size()
+            + self.num_stops.size()
+            + {
+                let block_len: usize = self.stops.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.colors.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Color>());
+                block_len + pad
+            }
+    }
+}
+impl Request for CreateLinearGradientRequest {
+    const OPCODE: u8 = 34;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateRadialGradientRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub inner: Pointfix,
+    pub outer: Pointfix,
+    pub inner_radius: Fixed,
+    pub outer_radius: Fixed,
+    pub num_stops: Card32,
+    pub stops: Vec<Fixed>,
+    pub colors: Vec<Color>,
+}
+impl CreateRadialGradientRequest {}
+impl AsByteSequence for CreateRadialGradientRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.inner.as_bytes(&mut bytes[index..]);
+        index += self.outer.as_bytes(&mut bytes[index..]);
+        index += self.inner_radius.as_bytes(&mut bytes[index..]);
+        index += self.outer_radius.as_bytes(&mut bytes[index..]);
+        index += self.num_stops.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.stops, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        let block_len: usize = vector_as_bytes(&self.colors, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Color>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateRadialGradientRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (inner, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (outer, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (inner_radius, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (outer_radius, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (num_stops, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (stops, block_len): (Vec<Fixed>, usize) =
+            vector_from_bytes(&bytes[index..], (num_stops as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        let (colors, block_len): (Vec<Color>, usize) =
+            vector_from_bytes(&bytes[index..], (num_stops as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Color>());
+        Some((
+            CreateRadialGradientRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                inner: inner,
+                outer: outer,
+                inner_radius: inner_radius,
+                outer_radius: outer_radius,
+                num_stops: num_stops,
+                stops: stops,
+                colors: colors,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.picture.size()
+            + self.length.size()
+            + self.inner.size()
+            + self.outer.size()
+            + self.inner_radius.size()
+            + self.outer_radius.size()
+            + self.num_stops.size()
+            + {
+                let block_len: usize = self.stops.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.colors.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Color>());
+                block_len + pad
+            }
+    }
+}
+impl Request for CreateRadialGradientRequest {
+    const OPCODE: u8 = 35;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateConicalGradientRequest {
+    pub req_type: u8,
+    pub picture: Picture,
+    pub length: u16,
+    pub center: Pointfix,
+    pub angle: Fixed,
+    pub num_stops: Card32,
+    pub stops: Vec<Fixed>,
+    pub colors: Vec<Color>,
+}
+impl CreateConicalGradientRequest {}
+impl AsByteSequence for CreateConicalGradientRequest {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.req_type.as_bytes(&mut bytes[index..]);
+        index += self.picture.as_bytes(&mut bytes[index..]);
+        index += self.length.as_bytes(&mut bytes[index..]);
+        index += self.center.as_bytes(&mut bytes[index..]);
+        index += self.angle.as_bytes(&mut bytes[index..]);
+        index += self.num_stops.as_bytes(&mut bytes[index..]);
+        let block_len: usize = vector_as_bytes(&self.stops, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        let block_len: usize = vector_as_bytes(&self.colors, &mut bytes[index..]);
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Color>());
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateConicalGradientRequest from byte buffer");
+        let (req_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (picture, sz): (Picture, usize) = <Picture>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (length, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (center, sz): (Pointfix, usize) = <Pointfix>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (angle, sz): (Fixed, usize) = <Fixed>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (num_stops, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (stops, block_len): (Vec<Fixed>, usize) =
+            vector_from_bytes(&bytes[index..], (num_stops as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+        let (colors, block_len): (Vec<Color>, usize) =
+            vector_from_bytes(&bytes[index..], (num_stops as usize) as usize)?;
+        index += block_len;
+        index += buffer_pad(block_len, ::core::mem::align_of::<Color>());
+        Some((
+            CreateConicalGradientRequest {
+                req_type: req_type,
+                picture: picture,
+                length: length,
+                center: center,
+                angle: angle,
+                num_stops: num_stops,
+                stops: stops,
+                colors: colors,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.req_type.size()
+            + self.picture.size()
+            + self.length.size()
+            + self.center.size()
+            + self.angle.size()
+            + self.num_stops.size()
+            + {
+                let block_len: usize = self.stops.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Fixed>());
+                block_len + pad
+            }
+            + {
+                let block_len: usize = self.colors.iter().map(|i| i.size()).sum();
+                let pad: usize = buffer_pad(block_len, ::core::mem::align_of::<Color>());
+                block_len + pad
+            }
+    }
+}
+impl Request for CreateConicalGradientRequest {
+    const OPCODE: u8 = 36;
+    const EXTENSION: Option<&'static str> = Some("RENDER");
+    type Reply = ();
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PolyEdge {
+    Sharp = 0,
+    Smooth = 1,
+}
+impl AsByteSequence for PolyEdge {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        (*self as i32).as_bytes(bytes)
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Sharp, sz)),
+            1 => Some((Self::Smooth, sz)),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        ::core::mem::size_of::<i32>()
+    }
+}
+impl Default for PolyEdge {
+    #[inline]
+    fn default() -> PolyEdge {
+        PolyEdge::Sharp
+    }
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SubPixel {
+    Unknown = 0,
+    HorizontalRgb = 1,
+    HorizontalBgr = 2,
+    VerticalRgb = 3,
+    VerticalBgr = 4,
+    None = 5,
+}
+impl AsByteSequence for SubPixel {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        (*self as i32).as_bytes(bytes)
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Unknown, sz)),
+            1 => Some((Self::HorizontalRgb, sz)),
+            2 => Some((Self::HorizontalBgr, sz)),
+            3 => Some((Self::VerticalRgb, sz)),
+            4 => Some((Self::VerticalBgr, sz)),
+            5 => Some((Self::None, sz)),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        ::core::mem::size_of::<i32>()
+    }
+}
+impl Default for SubPixel {
+    #[inline]
+    fn default() -> SubPixel {
+        SubPixel::Unknown
+    }
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PolyMode {
+    Precise = 0,
+    Imprecise = 1,
+}
+impl AsByteSequence for PolyMode {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        (*self as i32).as_bytes(bytes)
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Precise, sz)),
+            1 => Some((Self::Imprecise, sz)),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        ::core::mem::size_of::<i32>()
+    }
+}
+impl Default for PolyMode {
+    #[inline]
+    fn default() -> PolyMode {
+        PolyMode::Precise
+    }
+}
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Repeat {
+    None = 0,
+    Normal = 1,
+    Pad = 2,
+    Reflect = 3,
+}
+impl AsByteSequence for Repeat {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        (*self as i32).as_bytes(bytes)
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::None, sz)),
+            1 => Some((Self::Normal, sz)),
+            2 => Some((Self::Pad, sz)),
+            3 => Some((Self::Reflect, sz)),
+            _ => None,
+        }
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        ::core::mem::size_of::<i32>()
+    }
+}
+impl Default for Repeat {
+    #[inline]
+    fn default() -> Repeat {
+        Repeat::None
+    }
+}

--- a/src/auto/xc_misc.rs
+++ b/src/auto/xc_misc.rs
@@ -55,6 +55,7 @@ impl AsByteSequence for GetVersionRequest {
 }
 impl Request for GetVersionRequest {
     const OPCODE: u8 = 0;
+    const EXTENSION: Option<&'static str> = Some("XC-MISC");
     type Reply = GetVersionReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -153,6 +154,7 @@ impl AsByteSequence for GetXidRangeRequest {
 }
 impl Request for GetXidRangeRequest {
     const OPCODE: u8 = 1;
+    const EXTENSION: Option<&'static str> = Some("XC-MISC");
     type Reply = GetXidRangeReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -254,6 +256,7 @@ impl AsByteSequence for GetXidListRequest {
 }
 impl Request for GetXidListRequest {
     const OPCODE: u8 = 2;
+    const EXTENSION: Option<&'static str> = Some("XC-MISC");
     type Reply = GetXidListReply;
 }
 #[derive(Clone, Debug, Default)]

--- a/src/auto/xproto.rs
+++ b/src/auto/xproto.rs
@@ -2824,6 +2824,7 @@ impl AsByteSequence for CreateWindowRequest {
 }
 impl Request for CreateWindowRequest {
     const OPCODE: u8 = 1;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u16)]
@@ -3424,6 +3425,7 @@ impl AsByteSequence for ChangeWindowAttributesRequest {
 }
 impl Request for ChangeWindowAttributesRequest {
     const OPCODE: u8 = 2;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -3470,6 +3472,7 @@ impl AsByteSequence for GetWindowAttributesRequest {
 }
 impl Request for GetWindowAttributesRequest {
     const OPCODE: u8 = 3;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetWindowAttributesReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -3735,6 +3738,7 @@ impl AsByteSequence for DestroyWindowRequest {
 }
 impl Request for DestroyWindowRequest {
     const OPCODE: u8 = 4;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -3781,6 +3785,7 @@ impl AsByteSequence for DestroySubwindowsRequest {
 }
 impl Request for DestroySubwindowsRequest {
     const OPCODE: u8 = 5;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -3830,6 +3835,7 @@ impl AsByteSequence for ChangeSaveSetRequest {
 }
 impl Request for ChangeSaveSetRequest {
     const OPCODE: u8 = 6;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -3928,6 +3934,7 @@ impl AsByteSequence for ReparentWindowRequest {
 }
 impl Request for ReparentWindowRequest {
     const OPCODE: u8 = 7;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -3974,6 +3981,7 @@ impl AsByteSequence for MapWindowRequest {
 }
 impl Request for MapWindowRequest {
     const OPCODE: u8 = 8;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -4020,6 +4028,7 @@ impl AsByteSequence for MapSubwindowsRequest {
 }
 impl Request for MapSubwindowsRequest {
     const OPCODE: u8 = 9;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -4066,6 +4075,7 @@ impl AsByteSequence for UnmapWindowRequest {
 }
 impl Request for UnmapWindowRequest {
     const OPCODE: u8 = 10;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -4112,6 +4122,7 @@ impl AsByteSequence for UnmapSubwindowsRequest {
 }
 impl Request for UnmapSubwindowsRequest {
     const OPCODE: u8 = 11;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -4263,6 +4274,7 @@ impl AsByteSequence for ConfigureWindowRequest {
 }
 impl Request for ConfigureWindowRequest {
     const OPCODE: u8 = 12;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -4312,6 +4324,7 @@ impl AsByteSequence for CirculateWindowRequest {
 }
 impl Request for CirculateWindowRequest {
     const OPCODE: u8 = 13;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -4389,6 +4402,7 @@ impl AsByteSequence for GetGeometryRequest {
 }
 impl Request for GetGeometryRequest {
     const OPCODE: u8 = 14;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetGeometryReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -4522,6 +4536,7 @@ impl AsByteSequence for QueryTreeRequest {
 }
 impl Request for QueryTreeRequest {
     const OPCODE: u8 = 15;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryTreeReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -4666,6 +4681,7 @@ impl AsByteSequence for InternAtomRequest {
 }
 impl Request for InternAtomRequest {
     const OPCODE: u8 = 16;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = InternAtomReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -4759,6 +4775,7 @@ impl AsByteSequence for GetAtomNameRequest {
 }
 impl Request for GetAtomNameRequest {
     const OPCODE: u8 = 17;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetAtomNameReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -4919,6 +4936,7 @@ impl AsByteSequence for ChangePropertyRequest {
 }
 impl Request for ChangePropertyRequest {
     const OPCODE: u8 = 18;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -5003,6 +5021,7 @@ impl AsByteSequence for DeletePropertyRequest {
 }
 impl Request for DeletePropertyRequest {
     const OPCODE: u8 = 19;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -5079,6 +5098,7 @@ impl AsByteSequence for GetPropertyRequest {
 }
 impl Request for GetPropertyRequest {
     const OPCODE: u8 = 20;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetPropertyReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -5239,6 +5259,7 @@ impl AsByteSequence for ListPropertiesRequest {
 }
 impl Request for ListPropertiesRequest {
     const OPCODE: u8 = 21;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ListPropertiesReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -5366,6 +5387,7 @@ impl AsByteSequence for SetSelectionOwnerRequest {
 }
 impl Request for SetSelectionOwnerRequest {
     const OPCODE: u8 = 22;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -5412,6 +5434,7 @@ impl AsByteSequence for GetSelectionOwnerRequest {
 }
 impl Request for GetSelectionOwnerRequest {
     const OPCODE: u8 = 23;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetSelectionOwnerReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -5532,6 +5555,7 @@ impl AsByteSequence for ConvertSelectionRequest {
 }
 impl Request for ConvertSelectionRequest {
     const OPCODE: u8 = 24;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -5596,6 +5620,7 @@ impl AsByteSequence for SendEventRequest {
 }
 impl Request for SendEventRequest {
     const OPCODE: u8 = 25;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u32)]
@@ -5715,6 +5740,7 @@ impl AsByteSequence for GrabPointerRequest {
 }
 impl Request for GrabPointerRequest {
     const OPCODE: u8 = 26;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GrabPointerReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -5875,6 +5901,7 @@ impl AsByteSequence for UngrabPointerRequest {
 }
 impl Request for UngrabPointerRequest {
     const OPCODE: u8 = 27;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -5972,6 +5999,7 @@ impl AsByteSequence for GrabButtonRequest {
 }
 impl Request for GrabButtonRequest {
     const OPCODE: u8 = 28;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -6271,6 +6299,7 @@ impl AsByteSequence for UngrabButtonRequest {
 }
 impl Request for UngrabButtonRequest {
     const OPCODE: u8 = 29;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -6335,6 +6364,7 @@ impl AsByteSequence for ChangeActivePointerGrabRequest {
 }
 impl Request for ChangeActivePointerGrabRequest {
     const OPCODE: u8 = 30;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -6408,6 +6438,7 @@ impl AsByteSequence for GrabKeyboardRequest {
 }
 impl Request for GrabKeyboardRequest {
     const OPCODE: u8 = 31;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GrabKeyboardReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -6499,6 +6530,7 @@ impl AsByteSequence for UngrabKeyboardRequest {
 }
 impl Request for UngrabKeyboardRequest {
     const OPCODE: u8 = 32;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -6578,6 +6610,7 @@ impl AsByteSequence for GrabKeyRequest {
 }
 impl Request for GrabKeyRequest {
     const OPCODE: u8 = 33;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -6668,6 +6701,7 @@ impl AsByteSequence for UngrabKeyRequest {
 }
 impl Request for UngrabKeyRequest {
     const OPCODE: u8 = 34;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -6717,6 +6751,7 @@ impl AsByteSequence for AllowEventsRequest {
 }
 impl Request for AllowEventsRequest {
     const OPCODE: u8 = 35;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -6801,6 +6836,7 @@ impl AsByteSequence for GrabServerRequest {
 }
 impl Request for GrabServerRequest {
     const OPCODE: u8 = 36;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -6842,6 +6878,7 @@ impl AsByteSequence for UngrabServerRequest {
 }
 impl Request for UngrabServerRequest {
     const OPCODE: u8 = 37;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -6888,6 +6925,7 @@ impl AsByteSequence for QueryPointerRequest {
 }
 impl Request for QueryPointerRequest {
     const OPCODE: u8 = 38;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryPointerReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -7082,6 +7120,7 @@ impl AsByteSequence for GetMotionEventsRequest {
 }
 impl Request for GetMotionEventsRequest {
     const OPCODE: u8 = 39;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetMotionEventsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -7215,6 +7254,7 @@ impl AsByteSequence for TranslateCoordinatesRequest {
 }
 impl Request for TranslateCoordinatesRequest {
     const OPCODE: u8 = 40;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = TranslateCoordinatesReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -7372,6 +7412,7 @@ impl AsByteSequence for WarpPointerRequest {
 }
 impl Request for WarpPointerRequest {
     const OPCODE: u8 = 41;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -7430,6 +7471,7 @@ impl AsByteSequence for SetInputFocusRequest {
 }
 impl Request for SetInputFocusRequest {
     const OPCODE: u8 = 42;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -7506,6 +7548,7 @@ impl AsByteSequence for GetInputFocusRequest {
 }
 impl Request for GetInputFocusRequest {
     const OPCODE: u8 = 43;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetInputFocusReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -7601,6 +7644,7 @@ impl AsByteSequence for QueryKeymapRequest {
 }
 impl Request for QueryKeymapRequest {
     const OPCODE: u8 = 44;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryKeymapReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -7717,6 +7761,7 @@ impl AsByteSequence for OpenFontRequest {
 }
 impl Request for OpenFontRequest {
     const OPCODE: u8 = 45;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -7763,6 +7808,7 @@ impl AsByteSequence for CloseFontRequest {
 }
 impl Request for CloseFontRequest {
     const OPCODE: u8 = 46;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -7904,6 +7950,7 @@ impl AsByteSequence for QueryFontRequest {
 }
 impl Request for QueryFontRequest {
     const OPCODE: u8 = 47;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryFontReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -8142,6 +8189,7 @@ impl AsByteSequence for QueryTextExtentsRequest {
 }
 impl Request for QueryTextExtentsRequest {
     const OPCODE: u8 = 48;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryTextExtentsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -8334,6 +8382,7 @@ impl AsByteSequence for ListFontsRequest {
 }
 impl Request for ListFontsRequest {
     const OPCODE: u8 = 49;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ListFontsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -8467,6 +8516,7 @@ impl AsByteSequence for ListFontsWithInfoRequest {
 }
 impl Request for ListFontsWithInfoRequest {
     const OPCODE: u8 = 50;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ListFontsWithInfoReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -8678,6 +8728,7 @@ impl AsByteSequence for SetFontPathRequest {
 }
 impl Request for SetFontPathRequest {
     const OPCODE: u8 = 51;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -8719,6 +8770,7 @@ impl AsByteSequence for GetFontPathRequest {
 }
 impl Request for GetFontPathRequest {
     const OPCODE: u8 = 52;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetFontPathReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -8855,6 +8907,7 @@ impl AsByteSequence for CreatePixmapRequest {
 }
 impl Request for CreatePixmapRequest {
     const OPCODE: u8 = 53;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -8901,6 +8954,7 @@ impl AsByteSequence for FreePixmapRequest {
 }
 impl Request for FreePixmapRequest {
     const OPCODE: u8 = 54;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -9264,6 +9318,7 @@ impl AsByteSequence for CreateGcRequest {
 }
 impl Request for CreateGcRequest {
     const OPCODE: u8 = 55;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(transparent)]
@@ -10086,6 +10141,7 @@ impl AsByteSequence for ChangeGcRequest {
 }
 impl Request for ChangeGcRequest {
     const OPCODE: u8 = 56;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10147,6 +10203,7 @@ impl AsByteSequence for CopyGcRequest {
 }
 impl Request for CopyGcRequest {
     const OPCODE: u8 = 57;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10220,6 +10277,7 @@ impl AsByteSequence for SetDashesRequest {
 }
 impl Request for SetDashesRequest {
     const OPCODE: u8 = 58;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10298,6 +10356,7 @@ impl AsByteSequence for SetClipRectanglesRequest {
 }
 impl Request for SetClipRectanglesRequest {
     const OPCODE: u8 = 59;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -10379,6 +10438,7 @@ impl AsByteSequence for FreeGcRequest {
 }
 impl Request for FreeGcRequest {
     const OPCODE: u8 = 60;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10455,6 +10515,7 @@ impl AsByteSequence for ClearAreaRequest {
 }
 impl Request for ClearAreaRequest {
     const OPCODE: u8 = 61;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10552,6 +10613,7 @@ impl AsByteSequence for CopyAreaRequest {
 }
 impl Request for CopyAreaRequest {
     const OPCODE: u8 = 62;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10655,6 +10717,7 @@ impl AsByteSequence for CopyPlaneRequest {
 }
 impl Request for CopyPlaneRequest {
     const OPCODE: u8 = 63;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10727,6 +10790,7 @@ impl AsByteSequence for PolyPointRequest {
 }
 impl Request for PolyPointRequest {
     const OPCODE: u8 = 64;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -10830,6 +10894,7 @@ impl AsByteSequence for PolyLineRequest {
 }
 impl Request for PolyLineRequest {
     const OPCODE: u8 = 65;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -10939,6 +11004,7 @@ impl AsByteSequence for PolySegmentRequest {
 }
 impl Request for PolySegmentRequest {
     const OPCODE: u8 = 66;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11003,6 +11069,7 @@ impl AsByteSequence for PolyRectangleRequest {
 }
 impl Request for PolyRectangleRequest {
     const OPCODE: u8 = 67;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11067,6 +11134,7 @@ impl AsByteSequence for PolyArcRequest {
 }
 impl Request for PolyArcRequest {
     const OPCODE: u8 = 68;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11151,6 +11219,7 @@ impl AsByteSequence for FillPolyRequest {
 }
 impl Request for FillPolyRequest {
     const OPCODE: u8 = 69;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -11248,6 +11317,7 @@ impl AsByteSequence for PolyFillRectangleRequest {
 }
 impl Request for PolyFillRectangleRequest {
     const OPCODE: u8 = 70;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11312,6 +11382,7 @@ impl AsByteSequence for PolyFillArcRequest {
 }
 impl Request for PolyFillArcRequest {
     const OPCODE: u8 = 71;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11423,6 +11494,7 @@ impl AsByteSequence for PutImageRequest {
 }
 impl Request for PutImageRequest {
     const OPCODE: u8 = 72;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -11538,6 +11610,7 @@ impl AsByteSequence for GetImageRequest {
 }
 impl Request for GetImageRequest {
     const OPCODE: u8 = 73;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetImageReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -11690,6 +11763,7 @@ impl AsByteSequence for PolyText8Request {
 }
 impl Request for PolyText8Request {
     const OPCODE: u8 = 74;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11771,6 +11845,7 @@ impl AsByteSequence for PolyText16Request {
 }
 impl Request for PolyText16Request {
     const OPCODE: u8 = 75;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11853,6 +11928,7 @@ impl AsByteSequence for ImageText8Request {
 }
 impl Request for ImageText8Request {
     const OPCODE: u8 = 76;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11935,6 +12011,7 @@ impl AsByteSequence for ImageText16Request {
 }
 impl Request for ImageText16Request {
     const OPCODE: u8 = 77;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -11999,6 +12076,7 @@ impl AsByteSequence for CreateColormapRequest {
 }
 impl Request for CreateColormapRequest {
     const OPCODE: u8 = 78;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -12076,6 +12154,7 @@ impl AsByteSequence for FreeColormapRequest {
 }
 impl Request for FreeColormapRequest {
     const OPCODE: u8 = 79;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -12127,6 +12206,7 @@ impl AsByteSequence for CopyColormapAndFreeRequest {
 }
 impl Request for CopyColormapAndFreeRequest {
     const OPCODE: u8 = 80;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -12173,6 +12253,7 @@ impl AsByteSequence for InstallColormapRequest {
 }
 impl Request for InstallColormapRequest {
     const OPCODE: u8 = 81;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -12219,6 +12300,7 @@ impl AsByteSequence for UninstallColormapRequest {
 }
 impl Request for UninstallColormapRequest {
     const OPCODE: u8 = 82;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -12265,6 +12347,7 @@ impl AsByteSequence for ListInstalledColormapsRequest {
 }
 impl Request for ListInstalledColormapsRequest {
     const OPCODE: u8 = 83;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ListInstalledColormapsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -12401,6 +12484,7 @@ impl AsByteSequence for AllocColorRequest {
 }
 impl Request for AllocColorRequest {
     const OPCODE: u8 = 84;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = AllocColorReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -12542,6 +12626,7 @@ impl AsByteSequence for AllocNamedColorRequest {
 }
 impl Request for AllocNamedColorRequest {
     const OPCODE: u8 = 85;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = AllocNamedColorReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -12693,6 +12778,7 @@ impl AsByteSequence for AllocColorCellsRequest {
 }
 impl Request for AllocColorCellsRequest {
     const OPCODE: u8 = 86;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = AllocColorCellsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -12853,6 +12939,7 @@ impl AsByteSequence for AllocColorPlanesRequest {
 }
 impl Request for AllocColorPlanesRequest {
     const OPCODE: u8 = 87;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = AllocColorPlanesReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -13009,6 +13096,7 @@ impl AsByteSequence for FreeColorsRequest {
 }
 impl Request for FreeColorsRequest {
     const OPCODE: u8 = 88;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -13206,6 +13294,7 @@ impl AsByteSequence for StoreColorsRequest {
 }
 impl Request for StoreColorsRequest {
     const OPCODE: u8 = 89;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -13284,6 +13373,7 @@ impl AsByteSequence for StoreNamedColorRequest {
 }
 impl Request for StoreNamedColorRequest {
     const OPCODE: u8 = 90;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -13385,6 +13475,7 @@ impl AsByteSequence for QueryColorsRequest {
 }
 impl Request for QueryColorsRequest {
     const OPCODE: u8 = 91;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryColorsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -13520,6 +13611,7 @@ impl AsByteSequence for LookupColorRequest {
 }
 impl Request for LookupColorRequest {
     const OPCODE: u8 = 92;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = LookupColorReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -13710,6 +13802,7 @@ impl AsByteSequence for CreateCursorRequest {
 }
 impl Request for CreateCursorRequest {
     const OPCODE: u8 = 93;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 pub const PIXMAP_NONE: Pixmap = <Pixmap>::const_from_xid(0);
@@ -13820,6 +13913,7 @@ impl AsByteSequence for CreateGlyphCursorRequest {
 }
 impl Request for CreateGlyphCursorRequest {
     const OPCODE: u8 = 94;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 pub const FONT_NONE: Font = <Font>::const_from_xid(0);
@@ -13867,6 +13961,7 @@ impl AsByteSequence for FreeCursorRequest {
 }
 impl Request for FreeCursorRequest {
     const OPCODE: u8 = 95;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -13952,6 +14047,7 @@ impl AsByteSequence for RecolorCursorRequest {
 }
 impl Request for RecolorCursorRequest {
     const OPCODE: u8 = 96;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -14016,6 +14112,7 @@ impl AsByteSequence for QueryBestSizeRequest {
 }
 impl Request for QueryBestSizeRequest {
     const OPCODE: u8 = 97;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryBestSizeReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -14164,6 +14261,7 @@ impl AsByteSequence for QueryExtensionRequest {
 }
 impl Request for QueryExtensionRequest {
     const OPCODE: u8 = 98;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = QueryExtensionReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -14274,6 +14372,7 @@ impl AsByteSequence for ListExtensionsRequest {
 }
 impl Request for ListExtensionsRequest {
     const OPCODE: u8 = 99;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ListExtensionsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -14414,6 +14513,7 @@ impl AsByteSequence for ChangeKeyboardMappingRequest {
 }
 impl Request for ChangeKeyboardMappingRequest {
     const OPCODE: u8 = 100;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -14469,6 +14569,7 @@ impl AsByteSequence for GetKeyboardMappingRequest {
 }
 impl Request for GetKeyboardMappingRequest {
     const OPCODE: u8 = 101;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetKeyboardMappingReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -14688,6 +14789,7 @@ impl AsByteSequence for ChangeKeyboardControlRequest {
 }
 impl Request for ChangeKeyboardControlRequest {
     const OPCODE: u8 = 102;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(transparent)]
@@ -14909,6 +15011,7 @@ impl AsByteSequence for GetKeyboardControlRequest {
 }
 impl Request for GetKeyboardControlRequest {
     const OPCODE: u8 = 103;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetKeyboardControlReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -15074,6 +15177,7 @@ impl AsByteSequence for BellRequest {
 }
 impl Request for BellRequest {
     const OPCODE: u8 = 104;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -15147,6 +15251,7 @@ impl AsByteSequence for ChangePointerControlRequest {
 }
 impl Request for ChangePointerControlRequest {
     const OPCODE: u8 = 105;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -15188,6 +15293,7 @@ impl AsByteSequence for GetPointerControlRequest {
 }
 impl Request for GetPointerControlRequest {
     const OPCODE: u8 = 106;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetPointerControlReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -15322,6 +15428,7 @@ impl AsByteSequence for SetScreenSaverRequest {
 }
 impl Request for SetScreenSaverRequest {
     const OPCODE: u8 = 107;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -15429,6 +15536,7 @@ impl AsByteSequence for GetScreenSaverRequest {
 }
 impl Request for GetScreenSaverRequest {
     const OPCODE: u8 = 108;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetScreenSaverReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -15574,6 +15682,7 @@ impl AsByteSequence for ChangeHostsRequest {
 }
 impl Request for ChangeHostsRequest {
     const OPCODE: u8 = 109;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -15731,6 +15840,7 @@ impl AsByteSequence for ListHostsRequest {
 }
 impl Request for ListHostsRequest {
     const OPCODE: u8 = 110;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ListHostsReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -15875,6 +15985,7 @@ impl AsByteSequence for SetAccessControlRequest {
 }
 impl Request for SetAccessControlRequest {
     const OPCODE: u8 = 111;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -15919,6 +16030,7 @@ impl AsByteSequence for SetCloseDownModeRequest {
 }
 impl Request for SetCloseDownModeRequest {
     const OPCODE: u8 = 112;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -15998,6 +16110,7 @@ impl AsByteSequence for KillClientRequest {
 }
 impl Request for KillClientRequest {
     const OPCODE: u8 = 113;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u32)]
@@ -16100,6 +16213,7 @@ impl AsByteSequence for RotatePropertiesRequest {
 }
 impl Request for RotatePropertiesRequest {
     const OPCODE: u8 = 114;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[derive(Clone, Debug, Default)]
@@ -16144,6 +16258,7 @@ impl AsByteSequence for ForceScreenSaverRequest {
 }
 impl Request for ForceScreenSaverRequest {
     const OPCODE: u8 = 115;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
 }
 #[repr(u8)]
@@ -16230,6 +16345,7 @@ impl AsByteSequence for SetPointerMappingRequest {
 }
 impl Request for SetPointerMappingRequest {
     const OPCODE: u8 = 116;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = SetPointerMappingReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -16349,6 +16465,7 @@ impl AsByteSequence for GetPointerMappingRequest {
 }
 impl Request for GetPointerMappingRequest {
     const OPCODE: u8 = 117;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetPointerMappingReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -16471,6 +16588,7 @@ impl AsByteSequence for SetModifierMappingRequest {
 }
 impl Request for SetModifierMappingRequest {
     const OPCODE: u8 = 118;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = SetModifierMappingReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -16557,6 +16675,7 @@ impl AsByteSequence for GetModifierMappingRequest {
 }
 impl Request for GetModifierMappingRequest {
     const OPCODE: u8 = 119;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = GetModifierMappingReply;
 }
 #[derive(Clone, Debug, Default)]
@@ -16665,75 +16784,8 @@ impl AsByteSequence for NoOperationRequest {
 }
 impl Request for NoOperationRequest {
     const OPCODE: u8 = 127;
+    const EXTENSION: Option<&'static str> = None;
     type Reply = ();
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum LineStyle {
-    Solid = 0,
-    OnOffDash = 1,
-    DoubleDash = 2,
-}
-impl AsByteSequence for LineStyle {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::Solid, sz)),
-            1 => Some((Self::OnOffDash, sz)),
-            2 => Some((Self::DoubleDash, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for LineStyle {
-    #[inline]
-    fn default() -> LineStyle {
-        LineStyle::Solid
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum CapStyle {
-    NotLast = 0,
-    Butt = 1,
-    Round = 2,
-    Projecting = 3,
-}
-impl AsByteSequence for CapStyle {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::NotLast, sz)),
-            1 => Some((Self::Butt, sz)),
-            2 => Some((Self::Round, sz)),
-            3 => Some((Self::Projecting, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for CapStyle {
-    #[inline]
-    fn default() -> CapStyle {
-        CapStyle::NotLast
-    }
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -16768,296 +16820,6 @@ impl Default for FillStyle {
     #[inline]
     fn default() -> FillStyle {
         FillStyle::Solid
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum LedMode {
-    Off = 0,
-    On = 1,
-}
-impl AsByteSequence for LedMode {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::Off, sz)),
-            1 => Some((Self::On, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for LedMode {
-    #[inline]
-    fn default() -> LedMode {
-        LedMode::Off
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum BackPixmap {
-    None = 0,
-    ParentRelative = 1,
-}
-impl AsByteSequence for BackPixmap {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::None, sz)),
-            1 => Some((Self::ParentRelative, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for BackPixmap {
-    #[inline]
-    fn default() -> BackPixmap {
-        BackPixmap::None
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum JoinStyle {
-    Miter = 0,
-    Round = 1,
-    Bevel = 2,
-}
-impl AsByteSequence for JoinStyle {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::Miter, sz)),
-            1 => Some((Self::Round, sz)),
-            2 => Some((Self::Bevel, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for JoinStyle {
-    #[inline]
-    fn default() -> JoinStyle {
-        JoinStyle::Miter
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum FillRule {
-    EvenOdd = 0,
-    Winding = 1,
-}
-impl AsByteSequence for FillRule {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::EvenOdd, sz)),
-            1 => Some((Self::Winding, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for FillRule {
-    #[inline]
-    fn default() -> FillRule {
-        FillRule::EvenOdd
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum MapIndex {
-    Shift = 0,
-    Lock = 1,
-    Control = 2,
-    One = 3,
-    Two = 4,
-    Three = 5,
-    Four = 6,
-    Five = 7,
-}
-impl AsByteSequence for MapIndex {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::Shift, sz)),
-            1 => Some((Self::Lock, sz)),
-            2 => Some((Self::Control, sz)),
-            3 => Some((Self::One, sz)),
-            4 => Some((Self::Two, sz)),
-            5 => Some((Self::Three, sz)),
-            6 => Some((Self::Four, sz)),
-            7 => Some((Self::Five, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for MapIndex {
-    #[inline]
-    fn default() -> MapIndex {
-        MapIndex::Shift
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Gx {
-    Clear = 0,
-    And = 1,
-    AndReverse = 2,
-    Copy = 3,
-    AndInverted = 4,
-    Noop = 5,
-    Xor = 6,
-    Or = 7,
-    Nor = 8,
-    Equiv = 9,
-    Invert = 10,
-    OrReverse = 11,
-    CopyInverted = 12,
-    OrInverted = 13,
-    Nand = 14,
-    Set = 15,
-}
-impl AsByteSequence for Gx {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::Clear, sz)),
-            1 => Some((Self::And, sz)),
-            2 => Some((Self::AndReverse, sz)),
-            3 => Some((Self::Copy, sz)),
-            4 => Some((Self::AndInverted, sz)),
-            5 => Some((Self::Noop, sz)),
-            6 => Some((Self::Xor, sz)),
-            7 => Some((Self::Or, sz)),
-            8 => Some((Self::Nor, sz)),
-            9 => Some((Self::Equiv, sz)),
-            10 => Some((Self::Invert, sz)),
-            11 => Some((Self::OrReverse, sz)),
-            12 => Some((Self::CopyInverted, sz)),
-            13 => Some((Self::OrInverted, sz)),
-            14 => Some((Self::Nand, sz)),
-            15 => Some((Self::Set, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for Gx {
-    #[inline]
-    fn default() -> Gx {
-        Gx::Clear
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum ArcMode {
-    Chord = 0,
-    PieSlice = 1,
-}
-impl AsByteSequence for ArcMode {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::Chord, sz)),
-            1 => Some((Self::PieSlice, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for ArcMode {
-    #[inline]
-    fn default() -> ArcMode {
-        ArcMode::Chord
-    }
-}
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SubwindowMode {
-    ClipByChildren = 0,
-    IncludeInferiors = 1,
-}
-impl AsByteSequence for SubwindowMode {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        (*self as i32).as_bytes(bytes)
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
-        match underlying {
-            0 => Some((Self::ClipByChildren, sz)),
-            1 => Some((Self::IncludeInferiors, sz)),
-            _ => None,
-        }
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        ::core::mem::size_of::<i32>()
-    }
-}
-impl Default for SubwindowMode {
-    #[inline]
-    fn default() -> SubwindowMode {
-        SubwindowMode::ClipByChildren
     }
 }
 #[repr(transparent)]
@@ -17195,785 +16957,363 @@ impl AsByteSequence for ButtonMask {
         self.inner.size()
     }
 }
-#[derive(Clone, Debug, Default)]
-pub struct RequestError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Gx {
+    Clear = 0,
+    And = 1,
+    AndReverse = 2,
+    Copy = 3,
+    AndInverted = 4,
+    Noop = 5,
+    Xor = 6,
+    Or = 7,
+    Nor = 8,
+    Equiv = 9,
+    Invert = 10,
+    OrReverse = 11,
+    CopyInverted = 12,
+    OrInverted = 13,
+    Nand = 14,
+    Set = 15,
 }
-impl RequestError {}
-impl AsByteSequence for RequestError {
+impl AsByteSequence for Gx {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing RequestError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            RequestError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Clear, sz)),
+            1 => Some((Self::And, sz)),
+            2 => Some((Self::AndReverse, sz)),
+            3 => Some((Self::Copy, sz)),
+            4 => Some((Self::AndInverted, sz)),
+            5 => Some((Self::Noop, sz)),
+            6 => Some((Self::Xor, sz)),
+            7 => Some((Self::Or, sz)),
+            8 => Some((Self::Nor, sz)),
+            9 => Some((Self::Equiv, sz)),
+            10 => Some((Self::Invert, sz)),
+            11 => Some((Self::OrReverse, sz)),
+            12 => Some((Self::CopyInverted, sz)),
+            13 => Some((Self::OrInverted, sz)),
+            14 => Some((Self::Nand, sz)),
+            15 => Some((Self::Set, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for RequestError {
-    const OPCODE: u8 = 1;
+impl Default for Gx {
+    #[inline]
+    fn default() -> Gx {
+        Gx::Clear
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct MatchError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LedMode {
+    Off = 0,
+    On = 1,
 }
-impl MatchError {}
-impl AsByteSequence for MatchError {
+impl AsByteSequence for LedMode {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing MatchError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            MatchError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Off, sz)),
+            1 => Some((Self::On, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for MatchError {
-    const OPCODE: u8 = 8;
+impl Default for LedMode {
+    #[inline]
+    fn default() -> LedMode {
+        LedMode::Off
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct PixmapError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum JoinStyle {
+    Miter = 0,
+    Round = 1,
+    Bevel = 2,
 }
-impl PixmapError {}
-impl AsByteSequence for PixmapError {
+impl AsByteSequence for JoinStyle {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing PixmapError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            PixmapError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Miter, sz)),
+            1 => Some((Self::Round, sz)),
+            2 => Some((Self::Bevel, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for PixmapError {
-    const OPCODE: u8 = 4;
+impl Default for JoinStyle {
+    #[inline]
+    fn default() -> JoinStyle {
+        JoinStyle::Miter
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct DrawableError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CapStyle {
+    NotLast = 0,
+    Butt = 1,
+    Round = 2,
+    Projecting = 3,
 }
-impl DrawableError {}
-impl AsByteSequence for DrawableError {
+impl AsByteSequence for CapStyle {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing DrawableError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            DrawableError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::NotLast, sz)),
+            1 => Some((Self::Butt, sz)),
+            2 => Some((Self::Round, sz)),
+            3 => Some((Self::Projecting, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for DrawableError {
-    const OPCODE: u8 = 9;
+impl Default for CapStyle {
+    #[inline]
+    fn default() -> CapStyle {
+        CapStyle::NotLast
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct IdChoiceError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LineStyle {
+    Solid = 0,
+    OnOffDash = 1,
+    DoubleDash = 2,
 }
-impl IdChoiceError {}
-impl AsByteSequence for IdChoiceError {
+impl AsByteSequence for LineStyle {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing IdChoiceError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            IdChoiceError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Solid, sz)),
+            1 => Some((Self::OnOffDash, sz)),
+            2 => Some((Self::DoubleDash, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for IdChoiceError {
-    const OPCODE: u8 = 14;
+impl Default for LineStyle {
+    #[inline]
+    fn default() -> LineStyle {
+        LineStyle::Solid
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct ValueError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum MapIndex {
+    Shift = 0,
+    Lock = 1,
+    Control = 2,
+    One = 3,
+    Two = 4,
+    Three = 5,
+    Four = 6,
+    Five = 7,
 }
-impl ValueError {}
-impl AsByteSequence for ValueError {
+impl AsByteSequence for MapIndex {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ValueError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            ValueError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Shift, sz)),
+            1 => Some((Self::Lock, sz)),
+            2 => Some((Self::Control, sz)),
+            3 => Some((Self::One, sz)),
+            4 => Some((Self::Two, sz)),
+            5 => Some((Self::Three, sz)),
+            6 => Some((Self::Four, sz)),
+            7 => Some((Self::Five, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for ValueError {
-    const OPCODE: u8 = 2;
+impl Default for MapIndex {
+    #[inline]
+    fn default() -> MapIndex {
+        MapIndex::Shift
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct WindowError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BackPixmap {
+    None = 0,
+    ParentRelative = 1,
 }
-impl WindowError {}
-impl AsByteSequence for WindowError {
+impl AsByteSequence for BackPixmap {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing WindowError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            WindowError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::None, sz)),
+            1 => Some((Self::ParentRelative, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for WindowError {
-    const OPCODE: u8 = 3;
+impl Default for BackPixmap {
+    #[inline]
+    fn default() -> BackPixmap {
+        BackPixmap::None
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct LengthError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ArcMode {
+    Chord = 0,
+    PieSlice = 1,
 }
-impl LengthError {}
-impl AsByteSequence for LengthError {
+impl AsByteSequence for ArcMode {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing LengthError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            LengthError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::Chord, sz)),
+            1 => Some((Self::PieSlice, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for LengthError {
-    const OPCODE: u8 = 16;
+impl Default for ArcMode {
+    #[inline]
+    fn default() -> ArcMode {
+        ArcMode::Chord
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct FontError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FillRule {
+    EvenOdd = 0,
+    Winding = 1,
 }
-impl FontError {}
-impl AsByteSequence for FontError {
+impl AsByteSequence for FillRule {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing FontError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            FontError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::EvenOdd, sz)),
+            1 => Some((Self::Winding, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for FontError {
-    const OPCODE: u8 = 7;
+impl Default for FillRule {
+    #[inline]
+    fn default() -> FillRule {
+        FillRule::EvenOdd
+    }
 }
-#[derive(Clone, Debug, Default)]
-pub struct AccessError {
-    pub _error_type: u8,
-    pub error_code: u8,
-    pub major_code: u8,
-    pub minor_code: u8,
-    pub sequence: u16,
-    pub bad_value: Card32,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
+#[repr(i32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SubwindowMode {
+    ClipByChildren = 0,
+    IncludeInferiors = 1,
 }
-impl AccessError {}
-impl AsByteSequence for AccessError {
+impl AsByteSequence for SubwindowMode {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self._error_type.as_bytes(&mut bytes[index..]);
-        index += self.error_code.as_bytes(&mut bytes[index..]);
-        index += self.major_code.as_bytes(&mut bytes[index..]);
-        index += self.minor_code.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.bad_value.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
+        (*self as i32).as_bytes(bytes)
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing AccessError from byte buffer");
-        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            AccessError {
-                _error_type: _error_type,
-                error_code: error_code,
-                major_code: major_code,
-                minor_code: minor_code,
-                sequence: sequence,
-                bad_value: bad_value,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
+        let (underlying, sz): (i32, usize) = <i32>::from_bytes(bytes)?;
+        match underlying {
+            0 => Some((Self::ClipByChildren, sz)),
+            1 => Some((Self::IncludeInferiors, sz)),
+            _ => None,
+        }
     }
     #[inline]
     fn size(&self) -> usize {
-        self._error_type.size()
-            + self.error_code.size()
-            + self.major_code.size()
-            + self.minor_code.size()
-            + self.sequence.size()
-            + self.bad_value.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-            + 1
+        ::core::mem::size_of::<i32>()
     }
 }
-impl Error for AccessError {
-    const OPCODE: u8 = 10;
+impl Default for SubwindowMode {
+    #[inline]
+    fn default() -> SubwindowMode {
+        SubwindowMode::ClipByChildren
+    }
 }
 #[derive(Clone, Debug, Default)]
 pub struct AllocError {
@@ -18054,7 +17394,7 @@ impl Error for AllocError {
     const OPCODE: u8 = 11;
 }
 #[derive(Clone, Debug, Default)]
-pub struct CursorError {
+pub struct RequestError {
     pub _error_type: u8,
     pub error_code: u8,
     pub major_code: u8,
@@ -18064,8 +17404,8 @@ pub struct CursorError {
     pub minor_opcode: Card16,
     pub major_opcode: Card8,
 }
-impl CursorError {}
-impl AsByteSequence for CursorError {
+impl RequestError {}
+impl AsByteSequence for RequestError {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
         let mut index: usize = 0;
@@ -18083,7 +17423,7 @@ impl AsByteSequence for CursorError {
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
         let mut index: usize = 0;
-        log::trace!("Deserializing CursorError from byte buffer");
+        log::trace!("Deserializing RequestError from byte buffer");
         let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
         index += sz;
         let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
@@ -18102,7 +17442,7 @@ impl AsByteSequence for CursorError {
         index += sz;
         index += 1;
         Some((
-            CursorError {
+            RequestError {
                 _error_type: _error_type,
                 error_code: error_code,
                 major_code: major_code,
@@ -18128,11 +17468,11 @@ impl AsByteSequence for CursorError {
             + 1
     }
 }
-impl Error for CursorError {
-    const OPCODE: u8 = 6;
+impl Error for RequestError {
+    const OPCODE: u8 = 1;
 }
 #[derive(Clone, Debug, Default)]
-pub struct ImplementationError {
+pub struct FontError {
     pub _error_type: u8,
     pub error_code: u8,
     pub major_code: u8,
@@ -18142,8 +17482,8 @@ pub struct ImplementationError {
     pub minor_opcode: Card16,
     pub major_opcode: Card8,
 }
-impl ImplementationError {}
-impl AsByteSequence for ImplementationError {
+impl FontError {}
+impl AsByteSequence for FontError {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
         let mut index: usize = 0;
@@ -18161,7 +17501,7 @@ impl AsByteSequence for ImplementationError {
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
         let mut index: usize = 0;
-        log::trace!("Deserializing ImplementationError from byte buffer");
+        log::trace!("Deserializing FontError from byte buffer");
         let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
         index += sz;
         let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
@@ -18180,7 +17520,7 @@ impl AsByteSequence for ImplementationError {
         index += sz;
         index += 1;
         Some((
-            ImplementationError {
+            FontError {
                 _error_type: _error_type,
                 error_code: error_code,
                 major_code: major_code,
@@ -18206,8 +17546,476 @@ impl AsByteSequence for ImplementationError {
             + 1
     }
 }
-impl Error for ImplementationError {
-    const OPCODE: u8 = 17;
+impl Error for FontError {
+    const OPCODE: u8 = 7;
+}
+#[derive(Clone, Debug, Default)]
+pub struct AtomError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl AtomError {}
+impl AsByteSequence for AtomError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing AtomError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            AtomError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for AtomError {
+    const OPCODE: u8 = 5;
+}
+#[derive(Clone, Debug, Default)]
+pub struct PixmapError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl PixmapError {}
+impl AsByteSequence for PixmapError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing PixmapError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            PixmapError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for PixmapError {
+    const OPCODE: u8 = 4;
+}
+#[derive(Clone, Debug, Default)]
+pub struct IdChoiceError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl IdChoiceError {}
+impl AsByteSequence for IdChoiceError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing IdChoiceError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            IdChoiceError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for IdChoiceError {
+    const OPCODE: u8 = 14;
+}
+#[derive(Clone, Debug, Default)]
+pub struct MatchError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl MatchError {}
+impl AsByteSequence for MatchError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing MatchError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            MatchError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for MatchError {
+    const OPCODE: u8 = 8;
+}
+#[derive(Clone, Debug, Default)]
+pub struct LengthError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl LengthError {}
+impl AsByteSequence for LengthError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing LengthError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            LengthError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for LengthError {
+    const OPCODE: u8 = 16;
+}
+#[derive(Clone, Debug, Default)]
+pub struct ColormapError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl ColormapError {}
+impl AsByteSequence for ColormapError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ColormapError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            ColormapError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for ColormapError {
+    const OPCODE: u8 = 12;
 }
 #[derive(Clone, Debug, Default)]
 pub struct GContextError {
@@ -18366,7 +18174,7 @@ impl Error for NameError {
     const OPCODE: u8 = 15;
 }
 #[derive(Clone, Debug, Default)]
-pub struct ColormapError {
+pub struct ValueError {
     pub _error_type: u8,
     pub error_code: u8,
     pub major_code: u8,
@@ -18376,8 +18184,8 @@ pub struct ColormapError {
     pub minor_opcode: Card16,
     pub major_opcode: Card8,
 }
-impl ColormapError {}
-impl AsByteSequence for ColormapError {
+impl ValueError {}
+impl AsByteSequence for ValueError {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
         let mut index: usize = 0;
@@ -18395,7 +18203,7 @@ impl AsByteSequence for ColormapError {
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
         let mut index: usize = 0;
-        log::trace!("Deserializing ColormapError from byte buffer");
+        log::trace!("Deserializing ValueError from byte buffer");
         let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
         index += sz;
         let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
@@ -18414,7 +18222,7 @@ impl AsByteSequence for ColormapError {
         index += sz;
         index += 1;
         Some((
-            ColormapError {
+            ValueError {
                 _error_type: _error_type,
                 error_code: error_code,
                 major_code: major_code,
@@ -18440,11 +18248,11 @@ impl AsByteSequence for ColormapError {
             + 1
     }
 }
-impl Error for ColormapError {
-    const OPCODE: u8 = 12;
+impl Error for ValueError {
+    const OPCODE: u8 = 2;
 }
 #[derive(Clone, Debug, Default)]
-pub struct AtomError {
+pub struct ImplementationError {
     pub _error_type: u8,
     pub error_code: u8,
     pub major_code: u8,
@@ -18454,8 +18262,8 @@ pub struct AtomError {
     pub minor_opcode: Card16,
     pub major_opcode: Card8,
 }
-impl AtomError {}
-impl AsByteSequence for AtomError {
+impl ImplementationError {}
+impl AsByteSequence for ImplementationError {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
         let mut index: usize = 0;
@@ -18473,7 +18281,7 @@ impl AsByteSequence for AtomError {
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
         let mut index: usize = 0;
-        log::trace!("Deserializing AtomError from byte buffer");
+        log::trace!("Deserializing ImplementationError from byte buffer");
         let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
         index += sz;
         let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
@@ -18492,7 +18300,7 @@ impl AsByteSequence for AtomError {
         index += sz;
         index += 1;
         Some((
-            AtomError {
+            ImplementationError {
                 _error_type: _error_type,
                 error_code: error_code,
                 major_code: major_code,
@@ -18518,51 +18326,359 @@ impl AsByteSequence for AtomError {
             + 1
     }
 }
-impl Error for AtomError {
-    const OPCODE: u8 = 5;
+impl Error for ImplementationError {
+    const OPCODE: u8 = 17;
 }
 #[derive(Clone, Debug, Default)]
-pub struct GraphicsExposureEvent {
+pub struct CursorError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl CursorError {}
+impl AsByteSequence for CursorError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CursorError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            CursorError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for CursorError {
+    const OPCODE: u8 = 6;
+}
+#[derive(Clone, Debug, Default)]
+pub struct WindowError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl WindowError {}
+impl AsByteSequence for WindowError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing WindowError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            WindowError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for WindowError {
+    const OPCODE: u8 = 3;
+}
+#[derive(Clone, Debug, Default)]
+pub struct AccessError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl AccessError {}
+impl AsByteSequence for AccessError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing AccessError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            AccessError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for AccessError {
+    const OPCODE: u8 = 10;
+}
+#[derive(Clone, Debug, Default)]
+pub struct DrawableError {
+    pub _error_type: u8,
+    pub error_code: u8,
+    pub major_code: u8,
+    pub minor_code: u8,
+    pub sequence: u16,
+    pub bad_value: Card32,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl DrawableError {}
+impl AsByteSequence for DrawableError {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self._error_type.as_bytes(&mut bytes[index..]);
+        index += self.error_code.as_bytes(&mut bytes[index..]);
+        index += self.major_code.as_bytes(&mut bytes[index..]);
+        index += self.minor_code.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.bad_value.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing DrawableError from byte buffer");
+        let (_error_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (error_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_code, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (bad_value, sz): (Card32, usize) = <Card32>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            DrawableError {
+                _error_type: _error_type,
+                error_code: error_code,
+                major_code: major_code,
+                minor_code: minor_code,
+                sequence: sequence,
+                bad_value: bad_value,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self._error_type.size()
+            + self.error_code.size()
+            + self.major_code.size()
+            + self.minor_code.size()
+            + self.sequence.size()
+            + self.bad_value.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+            + 1
+    }
+}
+impl Error for DrawableError {
+    const OPCODE: u8 = 9;
+}
+#[derive(Clone, Debug, Default)]
+pub struct ExposeEvent {
     pub event_type: u8,
     pub sequence: u16,
-    pub drawable: Drawable,
+    pub window: Window,
     pub x: Card16,
     pub y: Card16,
     pub width: Card16,
     pub height: Card16,
-    pub minor_opcode: Card16,
     pub count: Card16,
-    pub major_opcode: Card8,
 }
-impl GraphicsExposureEvent {}
-impl AsByteSequence for GraphicsExposureEvent {
+impl ExposeEvent {}
+impl AsByteSequence for ExposeEvent {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
         let mut index: usize = 0;
         index += self.event_type.as_bytes(&mut bytes[index..]);
         index += 1;
         index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.drawable.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
         index += self.x.as_bytes(&mut bytes[index..]);
         index += self.y.as_bytes(&mut bytes[index..]);
         index += self.width.as_bytes(&mut bytes[index..]);
         index += self.height.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
         index += self.count.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index += 3;
+        index += 2;
         index
     }
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
         let mut index: usize = 0;
-        log::trace!("Deserializing GraphicsExposureEvent from byte buffer");
+        log::trace!("Deserializing ExposeEvent from byte buffer");
         let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
         index += sz;
         index += 1;
         let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
         index += sz;
-        let (drawable, sz): (Drawable, usize) = <Drawable>::from_bytes(&bytes[index..])?;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
         index += sz;
         let (x, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
         index += sz;
@@ -18572,25 +18688,19 @@ impl AsByteSequence for GraphicsExposureEvent {
         index += sz;
         let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
         index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
         let (count, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
         index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
+        index += 2;
         Some((
-            GraphicsExposureEvent {
+            ExposeEvent {
                 event_type: event_type,
                 sequence: sequence,
-                drawable: drawable,
+                window: window,
                 x: x,
                 y: y,
                 width: width,
                 height: height,
-                minor_opcode: minor_opcode,
                 count: count,
-                major_opcode: major_opcode,
             },
             index,
         ))
@@ -18600,253 +18710,17 @@ impl AsByteSequence for GraphicsExposureEvent {
         self.event_type.size()
             + 1
             + self.sequence.size()
-            + self.drawable.size()
+            + self.window.size()
             + self.x.size()
             + self.y.size()
             + self.width.size()
             + self.height.size()
-            + self.minor_opcode.size()
             + self.count.size()
-            + self.major_opcode.size()
-            + 3
+            + 2
     }
 }
-impl Event for GraphicsExposureEvent {
-    const OPCODE: u8 = 13;
-}
-#[derive(Clone, Debug, Default)]
-pub struct UnmapNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-    pub from_configure: bool,
-}
-impl UnmapNotifyEvent {}
-impl AsByteSequence for UnmapNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.from_configure.as_bytes(&mut bytes[index..]);
-        index += 3;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing UnmapNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (from_configure, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
-        Some((
-            UnmapNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-                from_configure: from_configure,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.event.size()
-            + self.window.size()
-            + self.from_configure.size()
-            + 3
-    }
-}
-impl Event for UnmapNotifyEvent {
-    const OPCODE: u8 = 18;
-}
-#[derive(Clone, Debug, Default)]
-pub struct MotionNotifyEvent {
-    pub event_type: u8,
-    pub detail: Motion,
-    pub sequence: u16,
-    pub time: Timestamp,
-    pub root: Window,
-    pub event: Window,
-    pub child: Window,
-    pub root_x: Int16,
-    pub root_y: Int16,
-    pub event_x: Int16,
-    pub event_y: Int16,
-    pub state: KeyButMask,
-    pub same_screen: bool,
-}
-impl MotionNotifyEvent {}
-impl AsByteSequence for MotionNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.detail.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.time.as_bytes(&mut bytes[index..]);
-        index += self.root.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.child.as_bytes(&mut bytes[index..]);
-        index += self.root_x.as_bytes(&mut bytes[index..]);
-        index += self.root_y.as_bytes(&mut bytes[index..]);
-        index += self.event_x.as_bytes(&mut bytes[index..]);
-        index += self.event_y.as_bytes(&mut bytes[index..]);
-        index += self.state.as_bytes(&mut bytes[index..]);
-        index += self.same_screen.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing MotionNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (detail, sz): (Motion, usize) = <Motion>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            MotionNotifyEvent {
-                event_type: event_type,
-                detail: detail,
-                sequence: sequence,
-                time: time,
-                root: root,
-                event: event,
-                child: child,
-                root_x: root_x,
-                root_y: root_y,
-                event_x: event_x,
-                event_y: event_y,
-                state: state,
-                same_screen: same_screen,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + self.detail.size()
-            + self.sequence.size()
-            + self.time.size()
-            + self.root.size()
-            + self.event.size()
-            + self.child.size()
-            + self.root_x.size()
-            + self.root_y.size()
-            + self.event_x.size()
-            + self.event_y.size()
-            + self.state.size()
-            + self.same_screen.size()
-            + 1
-    }
-}
-impl Event for MotionNotifyEvent {
-    const OPCODE: u8 = 6;
-}
-#[derive(Clone, Debug, Default)]
-pub struct MapNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-    pub override_redirect: bool,
-}
-impl MapNotifyEvent {}
-impl AsByteSequence for MapNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.override_redirect.as_bytes(&mut bytes[index..]);
-        index += 3;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing MapNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
-        Some((
-            MapNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-                override_redirect: override_redirect,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.event.size()
-            + self.window.size()
-            + self.override_redirect.size()
-            + 3
-    }
-}
-impl Event for MapNotifyEvent {
-    const OPCODE: u8 = 19;
+impl Event for ExposeEvent {
+    const OPCODE: u8 = 12;
 }
 #[derive(Clone, Debug, Default)]
 pub struct EnterNotifyEvent {
@@ -18960,906 +18834,6 @@ impl Event for EnterNotifyEvent {
     const OPCODE: u8 = 7;
 }
 #[derive(Clone, Debug, Default)]
-pub struct ResizeRequestEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub window: Window,
-    pub width: Card16,
-    pub height: Card16,
-}
-impl ResizeRequestEvent {}
-impl AsByteSequence for ResizeRequestEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.width.as_bytes(&mut bytes[index..]);
-        index += self.height.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ResizeRequestEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            ResizeRequestEvent {
-                event_type: event_type,
-                sequence: sequence,
-                window: window,
-                width: width,
-                height: height,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.window.size()
-            + self.width.size()
-            + self.height.size()
-    }
-}
-impl Event for ResizeRequestEvent {
-    const OPCODE: u8 = 25;
-}
-#[derive(Clone, Debug, Default)]
-pub struct PropertyNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub window: Window,
-    pub atom: Atom,
-    pub time: Timestamp,
-    pub state: Property,
-}
-impl PropertyNotifyEvent {}
-impl AsByteSequence for PropertyNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.atom.as_bytes(&mut bytes[index..]);
-        index += self.time.as_bytes(&mut bytes[index..]);
-        index += self.state.as_bytes(&mut bytes[index..]);
-        index += 3;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing PropertyNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (atom, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (state, sz): (Property, usize) = <Property>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
-        Some((
-            PropertyNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                window: window,
-                atom: atom,
-                time: time,
-                state: state,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.window.size()
-            + self.atom.size()
-            + self.time.size()
-            + self.state.size()
-            + 3
-    }
-}
-impl Event for PropertyNotifyEvent {
-    const OPCODE: u8 = 28;
-}
-#[derive(Clone, Debug, Default)]
-pub struct KeymapNotifyEvent {
-    pub event_type: u8,
-    pub keys: [Card8; 31],
-    pub sequence: u16,
-}
-impl KeymapNotifyEvent {}
-impl AsByteSequence for KeymapNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.keys.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing KeymapNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (keys, sz): ([Card8; 31], usize) = <[Card8; 31]>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            KeymapNotifyEvent {
-                event_type: event_type,
-                keys: keys,
-                sequence: sequence,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size() + self.keys.size() + self.sequence.size()
-    }
-}
-impl Event for KeymapNotifyEvent {
-    const OPCODE: u8 = 11;
-}
-#[derive(Clone, Debug, Default)]
-pub struct ExposeEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub window: Window,
-    pub x: Card16,
-    pub y: Card16,
-    pub width: Card16,
-    pub height: Card16,
-    pub count: Card16,
-}
-impl ExposeEvent {}
-impl AsByteSequence for ExposeEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.x.as_bytes(&mut bytes[index..]);
-        index += self.y.as_bytes(&mut bytes[index..]);
-        index += self.width.as_bytes(&mut bytes[index..]);
-        index += self.height.as_bytes(&mut bytes[index..]);
-        index += self.count.as_bytes(&mut bytes[index..]);
-        index += 2;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ExposeEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (x, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (y, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (count, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 2;
-        Some((
-            ExposeEvent {
-                event_type: event_type,
-                sequence: sequence,
-                window: window,
-                x: x,
-                y: y,
-                width: width,
-                height: height,
-                count: count,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.window.size()
-            + self.x.size()
-            + self.y.size()
-            + self.width.size()
-            + self.height.size()
-            + self.count.size()
-            + 2
-    }
-}
-impl Event for ExposeEvent {
-    const OPCODE: u8 = 12;
-}
-#[derive(Clone, Debug, Default)]
-pub struct KeyPressEvent {
-    pub event_type: u8,
-    pub detail: Keycode,
-    pub sequence: u16,
-    pub time: Timestamp,
-    pub root: Window,
-    pub event: Window,
-    pub child: Window,
-    pub root_x: Int16,
-    pub root_y: Int16,
-    pub event_x: Int16,
-    pub event_y: Int16,
-    pub state: KeyButMask,
-    pub same_screen: bool,
-}
-impl KeyPressEvent {}
-impl AsByteSequence for KeyPressEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.detail.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.time.as_bytes(&mut bytes[index..]);
-        index += self.root.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.child.as_bytes(&mut bytes[index..]);
-        index += self.root_x.as_bytes(&mut bytes[index..]);
-        index += self.root_y.as_bytes(&mut bytes[index..]);
-        index += self.event_x.as_bytes(&mut bytes[index..]);
-        index += self.event_y.as_bytes(&mut bytes[index..]);
-        index += self.state.as_bytes(&mut bytes[index..]);
-        index += self.same_screen.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing KeyPressEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (detail, sz): (Keycode, usize) = <Keycode>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            KeyPressEvent {
-                event_type: event_type,
-                detail: detail,
-                sequence: sequence,
-                time: time,
-                root: root,
-                event: event,
-                child: child,
-                root_x: root_x,
-                root_y: root_y,
-                event_x: event_x,
-                event_y: event_y,
-                state: state,
-                same_screen: same_screen,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + self.detail.size()
-            + self.sequence.size()
-            + self.time.size()
-            + self.root.size()
-            + self.event.size()
-            + self.child.size()
-            + self.root_x.size()
-            + self.root_y.size()
-            + self.event_x.size()
-            + self.event_y.size()
-            + self.state.size()
-            + self.same_screen.size()
-            + 1
-    }
-}
-impl Event for KeyPressEvent {
-    const OPCODE: u8 = 2;
-}
-#[derive(Clone, Debug, Default)]
-pub struct ButtonReleaseEvent {
-    pub event_type: u8,
-    pub detail: Button,
-    pub sequence: u16,
-    pub time: Timestamp,
-    pub root: Window,
-    pub event: Window,
-    pub child: Window,
-    pub root_x: Int16,
-    pub root_y: Int16,
-    pub event_x: Int16,
-    pub event_y: Int16,
-    pub state: KeyButMask,
-    pub same_screen: bool,
-}
-impl ButtonReleaseEvent {}
-impl AsByteSequence for ButtonReleaseEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.detail.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.time.as_bytes(&mut bytes[index..]);
-        index += self.root.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.child.as_bytes(&mut bytes[index..]);
-        index += self.root_x.as_bytes(&mut bytes[index..]);
-        index += self.root_y.as_bytes(&mut bytes[index..]);
-        index += self.event_x.as_bytes(&mut bytes[index..]);
-        index += self.event_y.as_bytes(&mut bytes[index..]);
-        index += self.state.as_bytes(&mut bytes[index..]);
-        index += self.same_screen.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ButtonReleaseEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (detail, sz): (Button, usize) = <Button>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            ButtonReleaseEvent {
-                event_type: event_type,
-                detail: detail,
-                sequence: sequence,
-                time: time,
-                root: root,
-                event: event,
-                child: child,
-                root_x: root_x,
-                root_y: root_y,
-                event_x: event_x,
-                event_y: event_y,
-                state: state,
-                same_screen: same_screen,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + self.detail.size()
-            + self.sequence.size()
-            + self.time.size()
-            + self.root.size()
-            + self.event.size()
-            + self.child.size()
-            + self.root_x.size()
-            + self.root_y.size()
-            + self.event_x.size()
-            + self.event_y.size()
-            + self.state.size()
-            + self.same_screen.size()
-            + 1
-    }
-}
-impl Event for ButtonReleaseEvent {
-    const OPCODE: u8 = 5;
-}
-#[derive(Clone, Debug, Default)]
-pub struct FocusInEvent {
-    pub event_type: u8,
-    pub detail: NotifyDetail,
-    pub sequence: u16,
-    pub event: Window,
-    pub mode: NotifyMode,
-}
-impl FocusInEvent {}
-impl AsByteSequence for FocusInEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.detail.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.mode.as_bytes(&mut bytes[index..]);
-        index += 3;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing FocusInEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (detail, sz): (NotifyDetail, usize) = <NotifyDetail>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (mode, sz): (NotifyMode, usize) = <NotifyMode>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
-        Some((
-            FocusInEvent {
-                event_type: event_type,
-                detail: detail,
-                sequence: sequence,
-                event: event,
-                mode: mode,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + self.detail.size()
-            + self.sequence.size()
-            + self.event.size()
-            + self.mode.size()
-            + 3
-    }
-}
-impl Event for FocusInEvent {
-    const OPCODE: u8 = 9;
-}
-#[derive(Clone, Debug, Default)]
-pub struct ConfigureNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-    pub above_sibling: Window,
-    pub x: Int16,
-    pub y: Int16,
-    pub width: Card16,
-    pub height: Card16,
-    pub border_width: Card16,
-    pub override_redirect: bool,
-}
-impl ConfigureNotifyEvent {}
-impl AsByteSequence for ConfigureNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.above_sibling.as_bytes(&mut bytes[index..]);
-        index += self.x.as_bytes(&mut bytes[index..]);
-        index += self.y.as_bytes(&mut bytes[index..]);
-        index += self.width.as_bytes(&mut bytes[index..]);
-        index += self.height.as_bytes(&mut bytes[index..]);
-        index += self.border_width.as_bytes(&mut bytes[index..]);
-        index += self.override_redirect.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ConfigureNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (above_sibling, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (border_width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            ConfigureNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-                above_sibling: above_sibling,
-                x: x,
-                y: y,
-                width: width,
-                height: height,
-                border_width: border_width,
-                override_redirect: override_redirect,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.event.size()
-            + self.window.size()
-            + self.above_sibling.size()
-            + self.x.size()
-            + self.y.size()
-            + self.width.size()
-            + self.height.size()
-            + self.border_width.size()
-            + self.override_redirect.size()
-    }
-}
-impl Event for ConfigureNotifyEvent {
-    const OPCODE: u8 = 22;
-}
-#[derive(Clone, Debug, Default)]
-pub struct SelectionClearEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub time: Timestamp,
-    pub owner: Window,
-    pub selection: Atom,
-}
-impl SelectionClearEvent {}
-impl AsByteSequence for SelectionClearEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.time.as_bytes(&mut bytes[index..]);
-        index += self.owner.as_bytes(&mut bytes[index..]);
-        index += self.selection.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing SelectionClearEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (owner, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (selection, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            SelectionClearEvent {
-                event_type: event_type,
-                sequence: sequence,
-                time: time,
-                owner: owner,
-                selection: selection,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.time.size()
-            + self.owner.size()
-            + self.selection.size()
-    }
-}
-impl Event for SelectionClearEvent {
-    const OPCODE: u8 = 29;
-}
-#[derive(Clone, Debug, Default)]
-pub struct ConfigureRequestEvent {
-    pub event_type: u8,
-    pub stack_mode: StackMode,
-    pub sequence: u16,
-    pub parent: Window,
-    pub window: Window,
-    pub sibling: Window,
-    pub x: Int16,
-    pub y: Int16,
-    pub width: Card16,
-    pub height: Card16,
-    pub border_width: Card16,
-    pub value_mask: ConfigWindow,
-}
-impl ConfigureRequestEvent {}
-impl AsByteSequence for ConfigureRequestEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.stack_mode.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.parent.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.sibling.as_bytes(&mut bytes[index..]);
-        index += self.x.as_bytes(&mut bytes[index..]);
-        index += self.y.as_bytes(&mut bytes[index..]);
-        index += self.width.as_bytes(&mut bytes[index..]);
-        index += self.height.as_bytes(&mut bytes[index..]);
-        index += self.border_width.as_bytes(&mut bytes[index..]);
-        index += self.value_mask.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ConfigureRequestEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (stack_mode, sz): (StackMode, usize) = <StackMode>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sibling, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (border_width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (value_mask, sz): (ConfigWindow, usize) = <ConfigWindow>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            ConfigureRequestEvent {
-                event_type: event_type,
-                stack_mode: stack_mode,
-                sequence: sequence,
-                parent: parent,
-                window: window,
-                sibling: sibling,
-                x: x,
-                y: y,
-                width: width,
-                height: height,
-                border_width: border_width,
-                value_mask: value_mask,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + self.stack_mode.size()
-            + self.sequence.size()
-            + self.parent.size()
-            + self.window.size()
-            + self.sibling.size()
-            + self.x.size()
-            + self.y.size()
-            + self.width.size()
-            + self.height.size()
-            + self.border_width.size()
-            + self.value_mask.size()
-    }
-}
-impl Event for ConfigureRequestEvent {
-    const OPCODE: u8 = 23;
-}
-#[derive(Clone, Debug, Default)]
-pub struct GravityNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-    pub x: Int16,
-    pub y: Int16,
-}
-impl GravityNotifyEvent {}
-impl AsByteSequence for GravityNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.x.as_bytes(&mut bytes[index..]);
-        index += self.y.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing GravityNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            GravityNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-                x: x,
-                y: y,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.event.size()
-            + self.window.size()
-            + self.x.size()
-            + self.y.size()
-    }
-}
-impl Event for GravityNotifyEvent {
-    const OPCODE: u8 = 24;
-}
-#[derive(Clone, Debug, Default)]
-pub struct DestroyNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-}
-impl DestroyNotifyEvent {}
-impl AsByteSequence for DestroyNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing DestroyNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            DestroyNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size() + 1 + self.sequence.size() + self.event.size() + self.window.size()
-    }
-}
-impl Event for DestroyNotifyEvent {
-    const OPCODE: u8 = 17;
-}
-#[derive(Clone, Debug, Default)]
 pub struct LeaveNotifyEvent {
     pub event_type: u8,
     pub detail: NotifyDetail,
@@ -19969,6 +18943,679 @@ impl AsByteSequence for LeaveNotifyEvent {
 }
 impl Event for LeaveNotifyEvent {
     const OPCODE: u8 = 8;
+}
+#[derive(Clone, Debug, Default)]
+pub struct KeymapNotifyEvent {
+    pub event_type: u8,
+    pub keys: [Card8; 31],
+    pub sequence: u16,
+}
+impl KeymapNotifyEvent {}
+impl AsByteSequence for KeymapNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.keys.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing KeymapNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (keys, sz): ([Card8; 31], usize) = <[Card8; 31]>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            KeymapNotifyEvent {
+                event_type: event_type,
+                keys: keys,
+                sequence: sequence,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size() + self.keys.size() + self.sequence.size()
+    }
+}
+impl Event for KeymapNotifyEvent {
+    const OPCODE: u8 = 11;
+}
+#[derive(Clone, Debug, Default)]
+pub struct VisibilityNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub window: Window,
+    pub state: Visibility,
+}
+impl VisibilityNotifyEvent {}
+impl AsByteSequence for VisibilityNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.state.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing VisibilityNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (state, sz): (Visibility, usize) = <Visibility>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            VisibilityNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                window: window,
+                state: state,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.window.size()
+            + self.state.size()
+            + 3
+    }
+}
+impl Event for VisibilityNotifyEvent {
+    const OPCODE: u8 = 15;
+}
+#[derive(Clone, Debug, Default)]
+pub struct CreateNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub parent: Window,
+    pub window: Window,
+    pub x: Int16,
+    pub y: Int16,
+    pub width: Card16,
+    pub height: Card16,
+    pub border_width: Card16,
+    pub override_redirect: bool,
+}
+impl CreateNotifyEvent {}
+impl AsByteSequence for CreateNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.parent.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index += self.width.as_bytes(&mut bytes[index..]);
+        index += self.height.as_bytes(&mut bytes[index..]);
+        index += self.border_width.as_bytes(&mut bytes[index..]);
+        index += self.override_redirect.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CreateNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (border_width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            CreateNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                parent: parent,
+                window: window,
+                x: x,
+                y: y,
+                width: width,
+                height: height,
+                border_width: border_width,
+                override_redirect: override_redirect,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.parent.size()
+            + self.window.size()
+            + self.x.size()
+            + self.y.size()
+            + self.width.size()
+            + self.height.size()
+            + self.border_width.size()
+            + self.override_redirect.size()
+    }
+}
+impl Event for CreateNotifyEvent {
+    const OPCODE: u8 = 16;
+}
+#[derive(Clone, Debug, Default)]
+pub struct ReparentNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+    pub parent: Window,
+    pub x: Int16,
+    pub y: Int16,
+    pub override_redirect: bool,
+}
+impl ReparentNotifyEvent {}
+impl AsByteSequence for ReparentNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.parent.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index += self.override_redirect.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ReparentNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            ReparentNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+                parent: parent,
+                x: x,
+                y: y,
+                override_redirect: override_redirect,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.event.size()
+            + self.window.size()
+            + self.parent.size()
+            + self.x.size()
+            + self.y.size()
+            + self.override_redirect.size()
+            + 3
+    }
+}
+impl Event for ReparentNotifyEvent {
+    const OPCODE: u8 = 21;
+}
+#[derive(Clone, Debug, Default)]
+pub struct ResizeRequestEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub window: Window,
+    pub width: Card16,
+    pub height: Card16,
+}
+impl ResizeRequestEvent {}
+impl AsByteSequence for ResizeRequestEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.width.as_bytes(&mut bytes[index..]);
+        index += self.height.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ResizeRequestEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            ResizeRequestEvent {
+                event_type: event_type,
+                sequence: sequence,
+                window: window,
+                width: width,
+                height: height,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.window.size()
+            + self.width.size()
+            + self.height.size()
+    }
+}
+impl Event for ResizeRequestEvent {
+    const OPCODE: u8 = 25;
+}
+#[derive(Clone, Debug, Default)]
+pub struct CirculateNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+    pub place: Place,
+}
+impl CirculateNotifyEvent {}
+impl AsByteSequence for CirculateNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += 4;
+        index += self.place.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CirculateNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 4;
+        let (place, sz): (Place, usize) = <Place>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            CirculateNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+                place: place,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.event.size()
+            + self.window.size()
+            + 4
+            + self.place.size()
+            + 3
+    }
+}
+impl Event for CirculateNotifyEvent {
+    const OPCODE: u8 = 26;
+}
+#[derive(Clone, Debug, Default)]
+pub struct KeyReleaseEvent {
+    pub event_type: u8,
+    pub detail: Keycode,
+    pub sequence: u16,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Int16,
+    pub root_y: Int16,
+    pub event_x: Int16,
+    pub event_y: Int16,
+    pub state: KeyButMask,
+    pub same_screen: bool,
+}
+impl KeyReleaseEvent {}
+impl AsByteSequence for KeyReleaseEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.detail.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.time.as_bytes(&mut bytes[index..]);
+        index += self.root.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.child.as_bytes(&mut bytes[index..]);
+        index += self.root_x.as_bytes(&mut bytes[index..]);
+        index += self.root_y.as_bytes(&mut bytes[index..]);
+        index += self.event_x.as_bytes(&mut bytes[index..]);
+        index += self.event_y.as_bytes(&mut bytes[index..]);
+        index += self.state.as_bytes(&mut bytes[index..]);
+        index += self.same_screen.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing KeyReleaseEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (detail, sz): (Keycode, usize) = <Keycode>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            KeyReleaseEvent {
+                event_type: event_type,
+                detail: detail,
+                sequence: sequence,
+                time: time,
+                root: root,
+                event: event,
+                child: child,
+                root_x: root_x,
+                root_y: root_y,
+                event_x: event_x,
+                event_y: event_y,
+                state: state,
+                same_screen: same_screen,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + self.detail.size()
+            + self.sequence.size()
+            + self.time.size()
+            + self.root.size()
+            + self.event.size()
+            + self.child.size()
+            + self.root_x.size()
+            + self.root_y.size()
+            + self.event_x.size()
+            + self.event_y.size()
+            + self.state.size()
+            + self.same_screen.size()
+            + 1
+    }
+}
+impl Event for KeyReleaseEvent {
+    const OPCODE: u8 = 3;
+}
+#[derive(Clone, Debug, Default)]
+pub struct MotionNotifyEvent {
+    pub event_type: u8,
+    pub detail: Motion,
+    pub sequence: u16,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Int16,
+    pub root_y: Int16,
+    pub event_x: Int16,
+    pub event_y: Int16,
+    pub state: KeyButMask,
+    pub same_screen: bool,
+}
+impl MotionNotifyEvent {}
+impl AsByteSequence for MotionNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.detail.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.time.as_bytes(&mut bytes[index..]);
+        index += self.root.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.child.as_bytes(&mut bytes[index..]);
+        index += self.root_x.as_bytes(&mut bytes[index..]);
+        index += self.root_y.as_bytes(&mut bytes[index..]);
+        index += self.event_x.as_bytes(&mut bytes[index..]);
+        index += self.event_y.as_bytes(&mut bytes[index..]);
+        index += self.state.as_bytes(&mut bytes[index..]);
+        index += self.same_screen.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing MotionNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (detail, sz): (Motion, usize) = <Motion>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            MotionNotifyEvent {
+                event_type: event_type,
+                detail: detail,
+                sequence: sequence,
+                time: time,
+                root: root,
+                event: event,
+                child: child,
+                root_x: root_x,
+                root_y: root_y,
+                event_x: event_x,
+                event_y: event_y,
+                state: state,
+                same_screen: same_screen,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + self.detail.size()
+            + self.sequence.size()
+            + self.time.size()
+            + self.root.size()
+            + self.event.size()
+            + self.child.size()
+            + self.root_x.size()
+            + self.root_y.size()
+            + self.event_x.size()
+            + self.event_y.size()
+            + self.state.size()
+            + self.same_screen.size()
+            + 1
+    }
+}
+impl Event for MotionNotifyEvent {
+    const OPCODE: u8 = 6;
+}
+#[derive(Clone, Debug, Default)]
+pub struct FocusOutEvent {
+    pub event_type: u8,
+    pub detail: NotifyDetail,
+    pub sequence: u16,
+    pub event: Window,
+    pub mode: NotifyMode,
+}
+impl FocusOutEvent {}
+impl AsByteSequence for FocusOutEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.detail.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.mode.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing FocusOutEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (detail, sz): (NotifyDetail, usize) = <NotifyDetail>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (mode, sz): (NotifyMode, usize) = <NotifyMode>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            FocusOutEvent {
+                event_type: event_type,
+                detail: detail,
+                sequence: sequence,
+                event: event,
+                mode: mode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + self.detail.size()
+            + self.sequence.size()
+            + self.event.size()
+            + self.mode.size()
+            + 3
+    }
+}
+impl Event for FocusOutEvent {
+    const OPCODE: u8 = 10;
 }
 #[derive(Clone, Debug, Default)]
 pub struct SelectionNotifyEvent {
@@ -20121,651 +19768,6 @@ impl Event for SelectionRequestEvent {
     const OPCODE: u8 = 30;
 }
 #[derive(Clone, Debug, Default)]
-pub struct CirculateNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-    pub place: Place,
-}
-impl CirculateNotifyEvent {}
-impl AsByteSequence for CirculateNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += 4;
-        index += self.place.as_bytes(&mut bytes[index..]);
-        index += 3;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing CirculateNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 4;
-        let (place, sz): (Place, usize) = <Place>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
-        Some((
-            CirculateNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-                place: place,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.event.size()
-            + self.window.size()
-            + 4
-            + self.place.size()
-            + 3
-    }
-}
-impl Event for CirculateNotifyEvent {
-    const OPCODE: u8 = 26;
-}
-#[derive(Clone, Debug, Default)]
-pub struct ClientMessageEvent {
-    pub event_type: u8,
-    pub format: Card8,
-    pub sequence: u16,
-    pub window: Window,
-    pub ty: Atom,
-    pub data: ClientMessageData,
-}
-impl ClientMessageEvent {}
-impl AsByteSequence for ClientMessageEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.format.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.ty.as_bytes(&mut bytes[index..]);
-        index += self.data.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ClientMessageEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (format, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (ty, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (data, sz): (ClientMessageData, usize) =
-            <ClientMessageData>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            ClientMessageEvent {
-                event_type: event_type,
-                format: format,
-                sequence: sequence,
-                window: window,
-                ty: ty,
-                data: data,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + self.format.size()
-            + self.sequence.size()
-            + self.window.size()
-            + self.ty.size()
-            + self.data.size()
-    }
-}
-impl Event for ClientMessageEvent {
-    const OPCODE: u8 = 33;
-}
-#[derive(Clone, Debug, Default)]
-pub struct MappingNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub request: Mapping,
-    pub first_keycode: Keycode,
-    pub count: Card8,
-}
-impl MappingNotifyEvent {}
-impl AsByteSequence for MappingNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.request.as_bytes(&mut bytes[index..]);
-        index += self.first_keycode.as_bytes(&mut bytes[index..]);
-        index += self.count.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing MappingNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (request, sz): (Mapping, usize) = <Mapping>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (first_keycode, sz): (Keycode, usize) = <Keycode>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (count, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            MappingNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                request: request,
-                first_keycode: first_keycode,
-                count: count,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.request.size()
-            + self.first_keycode.size()
-            + self.count.size()
-    }
-}
-impl Event for MappingNotifyEvent {
-    const OPCODE: u8 = 34;
-}
-#[derive(Clone, Debug, Default)]
-pub struct MapRequestEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub parent: Window,
-    pub window: Window,
-}
-impl MapRequestEvent {}
-impl AsByteSequence for MapRequestEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.parent.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing MapRequestEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            MapRequestEvent {
-                event_type: event_type,
-                sequence: sequence,
-                parent: parent,
-                window: window,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size() + 1 + self.sequence.size() + self.parent.size() + self.window.size()
-    }
-}
-impl Event for MapRequestEvent {
-    const OPCODE: u8 = 20;
-}
-#[derive(Clone, Debug, Default)]
-pub struct ReparentNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-    pub parent: Window,
-    pub x: Int16,
-    pub y: Int16,
-    pub override_redirect: bool,
-}
-impl ReparentNotifyEvent {}
-impl AsByteSequence for ReparentNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.parent.as_bytes(&mut bytes[index..]);
-        index += self.x.as_bytes(&mut bytes[index..]);
-        index += self.y.as_bytes(&mut bytes[index..]);
-        index += self.override_redirect.as_bytes(&mut bytes[index..]);
-        index += 3;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing ReparentNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
-        Some((
-            ReparentNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-                parent: parent,
-                x: x,
-                y: y,
-                override_redirect: override_redirect,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.event.size()
-            + self.window.size()
-            + self.parent.size()
-            + self.x.size()
-            + self.y.size()
-            + self.override_redirect.size()
-            + 3
-    }
-}
-impl Event for ReparentNotifyEvent {
-    const OPCODE: u8 = 21;
-}
-#[derive(Clone, Debug, Default)]
-pub struct CirculateRequestEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub event: Window,
-    pub window: Window,
-    pub place: Place,
-}
-impl CirculateRequestEvent {}
-impl AsByteSequence for CirculateRequestEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += 4;
-        index += self.place.as_bytes(&mut bytes[index..]);
-        index += 3;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing CirculateRequestEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 4;
-        let (place, sz): (Place, usize) = <Place>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 3;
-        Some((
-            CirculateRequestEvent {
-                event_type: event_type,
-                sequence: sequence,
-                event: event,
-                window: window,
-                place: place,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.event.size()
-            + self.window.size()
-            + 4
-            + self.place.size()
-            + 3
-    }
-}
-impl Event for CirculateRequestEvent {
-    const OPCODE: u8 = 27;
-}
-#[derive(Clone, Debug, Default)]
-pub struct NoExposureEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub drawable: Drawable,
-    pub minor_opcode: Card16,
-    pub major_opcode: Card8,
-}
-impl NoExposureEvent {}
-impl AsByteSequence for NoExposureEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.drawable.as_bytes(&mut bytes[index..]);
-        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
-        index += self.major_opcode.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing NoExposureEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (drawable, sz): (Drawable, usize) = <Drawable>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            NoExposureEvent {
-                event_type: event_type,
-                sequence: sequence,
-                drawable: drawable,
-                minor_opcode: minor_opcode,
-                major_opcode: major_opcode,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.drawable.size()
-            + self.minor_opcode.size()
-            + self.major_opcode.size()
-    }
-}
-impl Event for NoExposureEvent {
-    const OPCODE: u8 = 14;
-}
-#[derive(Clone, Debug, Default)]
-pub struct CreateNotifyEvent {
-    pub event_type: u8,
-    pub sequence: u16,
-    pub parent: Window,
-    pub window: Window,
-    pub x: Int16,
-    pub y: Int16,
-    pub width: Card16,
-    pub height: Card16,
-    pub border_width: Card16,
-    pub override_redirect: bool,
-}
-impl CreateNotifyEvent {}
-impl AsByteSequence for CreateNotifyEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.parent.as_bytes(&mut bytes[index..]);
-        index += self.window.as_bytes(&mut bytes[index..]);
-        index += self.x.as_bytes(&mut bytes[index..]);
-        index += self.y.as_bytes(&mut bytes[index..]);
-        index += self.width.as_bytes(&mut bytes[index..]);
-        index += self.height.as_bytes(&mut bytes[index..]);
-        index += self.border_width.as_bytes(&mut bytes[index..]);
-        index += self.override_redirect.as_bytes(&mut bytes[index..]);
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing CreateNotifyEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (border_width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        Some((
-            CreateNotifyEvent {
-                event_type: event_type,
-                sequence: sequence,
-                parent: parent,
-                window: window,
-                x: x,
-                y: y,
-                width: width,
-                height: height,
-                border_width: border_width,
-                override_redirect: override_redirect,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + 1
-            + self.sequence.size()
-            + self.parent.size()
-            + self.window.size()
-            + self.x.size()
-            + self.y.size()
-            + self.width.size()
-            + self.height.size()
-            + self.border_width.size()
-            + self.override_redirect.size()
-    }
-}
-impl Event for CreateNotifyEvent {
-    const OPCODE: u8 = 16;
-}
-#[derive(Clone, Debug, Default)]
-pub struct KeyReleaseEvent {
-    pub event_type: u8,
-    pub detail: Keycode,
-    pub sequence: u16,
-    pub time: Timestamp,
-    pub root: Window,
-    pub event: Window,
-    pub child: Window,
-    pub root_x: Int16,
-    pub root_y: Int16,
-    pub event_x: Int16,
-    pub event_y: Int16,
-    pub state: KeyButMask,
-    pub same_screen: bool,
-}
-impl KeyReleaseEvent {}
-impl AsByteSequence for KeyReleaseEvent {
-    #[inline]
-    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
-        let mut index: usize = 0;
-        index += self.event_type.as_bytes(&mut bytes[index..]);
-        index += self.detail.as_bytes(&mut bytes[index..]);
-        index += self.sequence.as_bytes(&mut bytes[index..]);
-        index += self.time.as_bytes(&mut bytes[index..]);
-        index += self.root.as_bytes(&mut bytes[index..]);
-        index += self.event.as_bytes(&mut bytes[index..]);
-        index += self.child.as_bytes(&mut bytes[index..]);
-        index += self.root_x.as_bytes(&mut bytes[index..]);
-        index += self.root_y.as_bytes(&mut bytes[index..]);
-        index += self.event_x.as_bytes(&mut bytes[index..]);
-        index += self.event_y.as_bytes(&mut bytes[index..]);
-        index += self.state.as_bytes(&mut bytes[index..]);
-        index += self.same_screen.as_bytes(&mut bytes[index..]);
-        index += 1;
-        index
-    }
-    #[inline]
-    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
-        let mut index: usize = 0;
-        log::trace!("Deserializing KeyReleaseEvent from byte buffer");
-        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (detail, sz): (Keycode, usize) = <Keycode>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
-        index += sz;
-        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
-        index += sz;
-        index += 1;
-        Some((
-            KeyReleaseEvent {
-                event_type: event_type,
-                detail: detail,
-                sequence: sequence,
-                time: time,
-                root: root,
-                event: event,
-                child: child,
-                root_x: root_x,
-                root_y: root_y,
-                event_x: event_x,
-                event_y: event_y,
-                state: state,
-                same_screen: same_screen,
-            },
-            index,
-        ))
-    }
-    #[inline]
-    fn size(&self) -> usize {
-        self.event_type.size()
-            + self.detail.size()
-            + self.sequence.size()
-            + self.time.size()
-            + self.root.size()
-            + self.event.size()
-            + self.child.size()
-            + self.root_x.size()
-            + self.root_y.size()
-            + self.event_x.size()
-            + self.event_y.size()
-            + self.state.size()
-            + self.same_screen.size()
-            + 1
-    }
-}
-impl Event for KeyReleaseEvent {
-    const OPCODE: u8 = 3;
-}
-#[derive(Clone, Debug, Default)]
 pub struct ColormapNotifyEvent {
     pub event_type: u8,
     pub sequence: u16,
@@ -20835,6 +19837,479 @@ impl Event for ColormapNotifyEvent {
     const OPCODE: u8 = 32;
 }
 #[derive(Clone, Debug, Default)]
+pub struct GraphicsExposureEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub drawable: Drawable,
+    pub x: Card16,
+    pub y: Card16,
+    pub width: Card16,
+    pub height: Card16,
+    pub minor_opcode: Card16,
+    pub count: Card16,
+    pub major_opcode: Card8,
+}
+impl GraphicsExposureEvent {}
+impl AsByteSequence for GraphicsExposureEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.drawable.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index += self.width.as_bytes(&mut bytes[index..]);
+        index += self.height.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.count.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing GraphicsExposureEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (drawable, sz): (Drawable, usize) = <Drawable>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (count, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            GraphicsExposureEvent {
+                event_type: event_type,
+                sequence: sequence,
+                drawable: drawable,
+                x: x,
+                y: y,
+                width: width,
+                height: height,
+                minor_opcode: minor_opcode,
+                count: count,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.drawable.size()
+            + self.x.size()
+            + self.y.size()
+            + self.width.size()
+            + self.height.size()
+            + self.minor_opcode.size()
+            + self.count.size()
+            + self.major_opcode.size()
+            + 3
+    }
+}
+impl Event for GraphicsExposureEvent {
+    const OPCODE: u8 = 13;
+}
+#[derive(Clone, Debug, Default)]
+pub struct SelectionClearEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub time: Timestamp,
+    pub owner: Window,
+    pub selection: Atom,
+}
+impl SelectionClearEvent {}
+impl AsByteSequence for SelectionClearEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.time.as_bytes(&mut bytes[index..]);
+        index += self.owner.as_bytes(&mut bytes[index..]);
+        index += self.selection.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing SelectionClearEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (owner, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (selection, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            SelectionClearEvent {
+                event_type: event_type,
+                sequence: sequence,
+                time: time,
+                owner: owner,
+                selection: selection,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.time.size()
+            + self.owner.size()
+            + self.selection.size()
+    }
+}
+impl Event for SelectionClearEvent {
+    const OPCODE: u8 = 29;
+}
+#[derive(Clone, Debug, Default)]
+pub struct CirculateRequestEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+    pub place: Place,
+}
+impl CirculateRequestEvent {}
+impl AsByteSequence for CirculateRequestEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += 4;
+        index += self.place.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing CirculateRequestEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 4;
+        let (place, sz): (Place, usize) = <Place>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            CirculateRequestEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+                place: place,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.event.size()
+            + self.window.size()
+            + 4
+            + self.place.size()
+            + 3
+    }
+}
+impl Event for CirculateRequestEvent {
+    const OPCODE: u8 = 27;
+}
+#[derive(Clone, Debug, Default)]
+pub struct MapRequestEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub parent: Window,
+    pub window: Window,
+}
+impl MapRequestEvent {}
+impl AsByteSequence for MapRequestEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.parent.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing MapRequestEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            MapRequestEvent {
+                event_type: event_type,
+                sequence: sequence,
+                parent: parent,
+                window: window,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size() + 1 + self.sequence.size() + self.parent.size() + self.window.size()
+    }
+}
+impl Event for MapRequestEvent {
+    const OPCODE: u8 = 20;
+}
+#[derive(Clone, Debug, Default)]
+pub struct KeyPressEvent {
+    pub event_type: u8,
+    pub detail: Keycode,
+    pub sequence: u16,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Int16,
+    pub root_y: Int16,
+    pub event_x: Int16,
+    pub event_y: Int16,
+    pub state: KeyButMask,
+    pub same_screen: bool,
+}
+impl KeyPressEvent {}
+impl AsByteSequence for KeyPressEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.detail.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.time.as_bytes(&mut bytes[index..]);
+        index += self.root.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.child.as_bytes(&mut bytes[index..]);
+        index += self.root_x.as_bytes(&mut bytes[index..]);
+        index += self.root_y.as_bytes(&mut bytes[index..]);
+        index += self.event_x.as_bytes(&mut bytes[index..]);
+        index += self.event_y.as_bytes(&mut bytes[index..]);
+        index += self.state.as_bytes(&mut bytes[index..]);
+        index += self.same_screen.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing KeyPressEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (detail, sz): (Keycode, usize) = <Keycode>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            KeyPressEvent {
+                event_type: event_type,
+                detail: detail,
+                sequence: sequence,
+                time: time,
+                root: root,
+                event: event,
+                child: child,
+                root_x: root_x,
+                root_y: root_y,
+                event_x: event_x,
+                event_y: event_y,
+                state: state,
+                same_screen: same_screen,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + self.detail.size()
+            + self.sequence.size()
+            + self.time.size()
+            + self.root.size()
+            + self.event.size()
+            + self.child.size()
+            + self.root_x.size()
+            + self.root_y.size()
+            + self.event_x.size()
+            + self.event_y.size()
+            + self.state.size()
+            + self.same_screen.size()
+            + 1
+    }
+}
+impl Event for KeyPressEvent {
+    const OPCODE: u8 = 2;
+}
+#[derive(Clone, Debug, Default)]
+pub struct ConfigureNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+    pub above_sibling: Window,
+    pub x: Int16,
+    pub y: Int16,
+    pub width: Card16,
+    pub height: Card16,
+    pub border_width: Card16,
+    pub override_redirect: bool,
+}
+impl ConfigureNotifyEvent {}
+impl AsByteSequence for ConfigureNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.above_sibling.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index += self.width.as_bytes(&mut bytes[index..]);
+        index += self.height.as_bytes(&mut bytes[index..]);
+        index += self.border_width.as_bytes(&mut bytes[index..]);
+        index += self.override_redirect.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ConfigureNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (above_sibling, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (border_width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            ConfigureNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+                above_sibling: above_sibling,
+                x: x,
+                y: y,
+                width: width,
+                height: height,
+                border_width: border_width,
+                override_redirect: override_redirect,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.event.size()
+            + self.window.size()
+            + self.above_sibling.size()
+            + self.x.size()
+            + self.y.size()
+            + self.width.size()
+            + self.height.size()
+            + self.border_width.size()
+            + self.override_redirect.size()
+    }
+}
+impl Event for ConfigureNotifyEvent {
+    const OPCODE: u8 = 22;
+}
+#[derive(Clone, Debug, Default)]
 pub struct GeGenericEvent {
     pub event_type: u8,
     pub sequence: u16,
@@ -20875,15 +20350,65 @@ impl Event for GeGenericEvent {
     const OPCODE: u8 = 35;
 }
 #[derive(Clone, Debug, Default)]
-pub struct FocusOutEvent {
+pub struct DestroyNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+}
+impl DestroyNotifyEvent {}
+impl AsByteSequence for DestroyNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing DestroyNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            DestroyNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size() + 1 + self.sequence.size() + self.event.size() + self.window.size()
+    }
+}
+impl Event for DestroyNotifyEvent {
+    const OPCODE: u8 = 17;
+}
+#[derive(Clone, Debug, Default)]
+pub struct FocusInEvent {
     pub event_type: u8,
     pub detail: NotifyDetail,
     pub sequence: u16,
     pub event: Window,
     pub mode: NotifyMode,
 }
-impl FocusOutEvent {}
-impl AsByteSequence for FocusOutEvent {
+impl FocusInEvent {}
+impl AsByteSequence for FocusInEvent {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
         let mut index: usize = 0;
@@ -20898,7 +20423,7 @@ impl AsByteSequence for FocusOutEvent {
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
         let mut index: usize = 0;
-        log::trace!("Deserializing FocusOutEvent from byte buffer");
+        log::trace!("Deserializing FocusInEvent from byte buffer");
         let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
         index += sz;
         let (detail, sz): (NotifyDetail, usize) = <NotifyDetail>::from_bytes(&bytes[index..])?;
@@ -20911,7 +20436,7 @@ impl AsByteSequence for FocusOutEvent {
         index += sz;
         index += 3;
         Some((
-            FocusOutEvent {
+            FocusInEvent {
                 event_type: event_type,
                 detail: detail,
                 sequence: sequence,
@@ -20931,8 +20456,294 @@ impl AsByteSequence for FocusOutEvent {
             + 3
     }
 }
-impl Event for FocusOutEvent {
-    const OPCODE: u8 = 10;
+impl Event for FocusInEvent {
+    const OPCODE: u8 = 9;
+}
+#[derive(Clone, Debug, Default)]
+pub struct UnmapNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+    pub from_configure: bool,
+}
+impl UnmapNotifyEvent {}
+impl AsByteSequence for UnmapNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.from_configure.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing UnmapNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (from_configure, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            UnmapNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+                from_configure: from_configure,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.event.size()
+            + self.window.size()
+            + self.from_configure.size()
+            + 3
+    }
+}
+impl Event for UnmapNotifyEvent {
+    const OPCODE: u8 = 18;
+}
+#[derive(Clone, Debug, Default)]
+pub struct ClientMessageEvent {
+    pub event_type: u8,
+    pub format: Card8,
+    pub sequence: u16,
+    pub window: Window,
+    pub ty: Atom,
+    pub data: ClientMessageData,
+}
+impl ClientMessageEvent {}
+impl AsByteSequence for ClientMessageEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.format.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.ty.as_bytes(&mut bytes[index..]);
+        index += self.data.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ClientMessageEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (format, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (ty, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (data, sz): (ClientMessageData, usize) =
+            <ClientMessageData>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            ClientMessageEvent {
+                event_type: event_type,
+                format: format,
+                sequence: sequence,
+                window: window,
+                ty: ty,
+                data: data,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + self.format.size()
+            + self.sequence.size()
+            + self.window.size()
+            + self.ty.size()
+            + self.data.size()
+    }
+}
+impl Event for ClientMessageEvent {
+    const OPCODE: u8 = 33;
+}
+#[derive(Clone, Debug, Default)]
+pub struct ConfigureRequestEvent {
+    pub event_type: u8,
+    pub stack_mode: StackMode,
+    pub sequence: u16,
+    pub parent: Window,
+    pub window: Window,
+    pub sibling: Window,
+    pub x: Int16,
+    pub y: Int16,
+    pub width: Card16,
+    pub height: Card16,
+    pub border_width: Card16,
+    pub value_mask: ConfigWindow,
+}
+impl ConfigureRequestEvent {}
+impl AsByteSequence for ConfigureRequestEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.stack_mode.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.parent.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.sibling.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index += self.width.as_bytes(&mut bytes[index..]);
+        index += self.height.as_bytes(&mut bytes[index..]);
+        index += self.border_width.as_bytes(&mut bytes[index..]);
+        index += self.value_mask.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ConfigureRequestEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (stack_mode, sz): (StackMode, usize) = <StackMode>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (parent, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sibling, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (height, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (border_width, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (value_mask, sz): (ConfigWindow, usize) = <ConfigWindow>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            ConfigureRequestEvent {
+                event_type: event_type,
+                stack_mode: stack_mode,
+                sequence: sequence,
+                parent: parent,
+                window: window,
+                sibling: sibling,
+                x: x,
+                y: y,
+                width: width,
+                height: height,
+                border_width: border_width,
+                value_mask: value_mask,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + self.stack_mode.size()
+            + self.sequence.size()
+            + self.parent.size()
+            + self.window.size()
+            + self.sibling.size()
+            + self.x.size()
+            + self.y.size()
+            + self.width.size()
+            + self.height.size()
+            + self.border_width.size()
+            + self.value_mask.size()
+    }
+}
+impl Event for ConfigureRequestEvent {
+    const OPCODE: u8 = 23;
+}
+#[derive(Clone, Debug, Default)]
+pub struct MappingNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub request: Mapping,
+    pub first_keycode: Keycode,
+    pub count: Card8,
+}
+impl MappingNotifyEvent {}
+impl AsByteSequence for MappingNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.request.as_bytes(&mut bytes[index..]);
+        index += self.first_keycode.as_bytes(&mut bytes[index..]);
+        index += self.count.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing MappingNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (request, sz): (Mapping, usize) = <Mapping>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (first_keycode, sz): (Keycode, usize) = <Keycode>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (count, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            MappingNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                request: request,
+                first_keycode: first_keycode,
+                count: count,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.request.size()
+            + self.first_keycode.size()
+            + self.count.size()
+    }
+}
+impl Event for MappingNotifyEvent {
+    const OPCODE: u8 = 34;
 }
 #[derive(Clone, Debug, Default)]
 pub struct ButtonPressEvent {
@@ -21043,14 +20854,184 @@ impl Event for ButtonPressEvent {
     const OPCODE: u8 = 4;
 }
 #[derive(Clone, Debug, Default)]
-pub struct VisibilityNotifyEvent {
+pub struct ButtonReleaseEvent {
+    pub event_type: u8,
+    pub detail: Button,
+    pub sequence: u16,
+    pub time: Timestamp,
+    pub root: Window,
+    pub event: Window,
+    pub child: Window,
+    pub root_x: Int16,
+    pub root_y: Int16,
+    pub event_x: Int16,
+    pub event_y: Int16,
+    pub state: KeyButMask,
+    pub same_screen: bool,
+}
+impl ButtonReleaseEvent {}
+impl AsByteSequence for ButtonReleaseEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += self.detail.as_bytes(&mut bytes[index..]);
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.time.as_bytes(&mut bytes[index..]);
+        index += self.root.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.child.as_bytes(&mut bytes[index..]);
+        index += self.root_x.as_bytes(&mut bytes[index..]);
+        index += self.root_y.as_bytes(&mut bytes[index..]);
+        index += self.event_x.as_bytes(&mut bytes[index..]);
+        index += self.event_y.as_bytes(&mut bytes[index..]);
+        index += self.state.as_bytes(&mut bytes[index..]);
+        index += self.same_screen.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing ButtonReleaseEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (detail, sz): (Button, usize) = <Button>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (child, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (root_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event_y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (state, sz): (KeyButMask, usize) = <KeyButMask>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (same_screen, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        Some((
+            ButtonReleaseEvent {
+                event_type: event_type,
+                detail: detail,
+                sequence: sequence,
+                time: time,
+                root: root,
+                event: event,
+                child: child,
+                root_x: root_x,
+                root_y: root_y,
+                event_x: event_x,
+                event_y: event_y,
+                state: state,
+                same_screen: same_screen,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + self.detail.size()
+            + self.sequence.size()
+            + self.time.size()
+            + self.root.size()
+            + self.event.size()
+            + self.child.size()
+            + self.root_x.size()
+            + self.root_y.size()
+            + self.event_x.size()
+            + self.event_y.size()
+            + self.state.size()
+            + self.same_screen.size()
+            + 1
+    }
+}
+impl Event for ButtonReleaseEvent {
+    const OPCODE: u8 = 5;
+}
+#[derive(Clone, Debug, Default)]
+pub struct NoExposureEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub drawable: Drawable,
+    pub minor_opcode: Card16,
+    pub major_opcode: Card8,
+}
+impl NoExposureEvent {}
+impl AsByteSequence for NoExposureEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.drawable.as_bytes(&mut bytes[index..]);
+        index += self.minor_opcode.as_bytes(&mut bytes[index..]);
+        index += self.major_opcode.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing NoExposureEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (drawable, sz): (Drawable, usize) = <Drawable>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (minor_opcode, sz): (Card16, usize) = <Card16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (major_opcode, sz): (Card8, usize) = <Card8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            NoExposureEvent {
+                event_type: event_type,
+                sequence: sequence,
+                drawable: drawable,
+                minor_opcode: minor_opcode,
+                major_opcode: major_opcode,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.drawable.size()
+            + self.minor_opcode.size()
+            + self.major_opcode.size()
+    }
+}
+impl Event for NoExposureEvent {
+    const OPCODE: u8 = 14;
+}
+#[derive(Clone, Debug, Default)]
+pub struct PropertyNotifyEvent {
     pub event_type: u8,
     pub sequence: u16,
     pub window: Window,
-    pub state: Visibility,
+    pub atom: Atom,
+    pub time: Timestamp,
+    pub state: Property,
 }
-impl VisibilityNotifyEvent {}
-impl AsByteSequence for VisibilityNotifyEvent {
+impl PropertyNotifyEvent {}
+impl AsByteSequence for PropertyNotifyEvent {
     #[inline]
     fn as_bytes(&self, bytes: &mut [u8]) -> usize {
         let mut index: usize = 0;
@@ -21058,6 +21039,8 @@ impl AsByteSequence for VisibilityNotifyEvent {
         index += 1;
         index += self.sequence.as_bytes(&mut bytes[index..]);
         index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.atom.as_bytes(&mut bytes[index..]);
+        index += self.time.as_bytes(&mut bytes[index..]);
         index += self.state.as_bytes(&mut bytes[index..]);
         index += 3;
         index
@@ -21065,7 +21048,7 @@ impl AsByteSequence for VisibilityNotifyEvent {
     #[inline]
     fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
         let mut index: usize = 0;
-        log::trace!("Deserializing VisibilityNotifyEvent from byte buffer");
+        log::trace!("Deserializing PropertyNotifyEvent from byte buffer");
         let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
         index += sz;
         index += 1;
@@ -21073,14 +21056,20 @@ impl AsByteSequence for VisibilityNotifyEvent {
         index += sz;
         let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
         index += sz;
-        let (state, sz): (Visibility, usize) = <Visibility>::from_bytes(&bytes[index..])?;
+        let (atom, sz): (Atom, usize) = <Atom>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (time, sz): (Timestamp, usize) = <Timestamp>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (state, sz): (Property, usize) = <Property>::from_bytes(&bytes[index..])?;
         index += sz;
         index += 3;
         Some((
-            VisibilityNotifyEvent {
+            PropertyNotifyEvent {
                 event_type: event_type,
                 sequence: sequence,
                 window: window,
+                atom: atom,
+                time: time,
                 state: state,
             },
             index,
@@ -21092,10 +21081,141 @@ impl AsByteSequence for VisibilityNotifyEvent {
             + 1
             + self.sequence.size()
             + self.window.size()
+            + self.atom.size()
+            + self.time.size()
             + self.state.size()
             + 3
     }
 }
-impl Event for VisibilityNotifyEvent {
-    const OPCODE: u8 = 15;
+impl Event for PropertyNotifyEvent {
+    const OPCODE: u8 = 28;
+}
+#[derive(Clone, Debug, Default)]
+pub struct GravityNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+    pub x: Int16,
+    pub y: Int16,
+}
+impl GravityNotifyEvent {}
+impl AsByteSequence for GravityNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.x.as_bytes(&mut bytes[index..]);
+        index += self.y.as_bytes(&mut bytes[index..]);
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing GravityNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (x, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (y, sz): (Int16, usize) = <Int16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        Some((
+            GravityNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+                x: x,
+                y: y,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.event.size()
+            + self.window.size()
+            + self.x.size()
+            + self.y.size()
+    }
+}
+impl Event for GravityNotifyEvent {
+    const OPCODE: u8 = 24;
+}
+#[derive(Clone, Debug, Default)]
+pub struct MapNotifyEvent {
+    pub event_type: u8,
+    pub sequence: u16,
+    pub event: Window,
+    pub window: Window,
+    pub override_redirect: bool,
+}
+impl MapNotifyEvent {}
+impl AsByteSequence for MapNotifyEvent {
+    #[inline]
+    fn as_bytes(&self, bytes: &mut [u8]) -> usize {
+        let mut index: usize = 0;
+        index += self.event_type.as_bytes(&mut bytes[index..]);
+        index += 1;
+        index += self.sequence.as_bytes(&mut bytes[index..]);
+        index += self.event.as_bytes(&mut bytes[index..]);
+        index += self.window.as_bytes(&mut bytes[index..]);
+        index += self.override_redirect.as_bytes(&mut bytes[index..]);
+        index += 3;
+        index
+    }
+    #[inline]
+    fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+        let mut index: usize = 0;
+        log::trace!("Deserializing MapNotifyEvent from byte buffer");
+        let (event_type, sz): (u8, usize) = <u8>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 1;
+        let (sequence, sz): (u16, usize) = <u16>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (event, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (window, sz): (Window, usize) = <Window>::from_bytes(&bytes[index..])?;
+        index += sz;
+        let (override_redirect, sz): (bool, usize) = <bool>::from_bytes(&bytes[index..])?;
+        index += sz;
+        index += 3;
+        Some((
+            MapNotifyEvent {
+                event_type: event_type,
+                sequence: sequence,
+                event: event,
+                window: window,
+                override_redirect: override_redirect,
+            },
+            index,
+        ))
+    }
+    #[inline]
+    fn size(&self) -> usize {
+        self.event_type.size()
+            + 1
+            + self.sequence.size()
+            + self.event.size()
+            + self.window.size()
+            + self.override_redirect.size()
+            + 3
+    }
+}
+impl Event for MapNotifyEvent {
+    const OPCODE: u8 = 19;
 }

--- a/src/display/connection.rs
+++ b/src/display/connection.rs
@@ -27,7 +27,7 @@ pub type GenericFuture<'future> = Pin<Box<dyn Future<Output = crate::Result> + S
 
 /// A trait that represents the ability to send and receive bytes across a connection. This is used as a two-way
 /// stream to send and receive data from the X server.
-pub trait Connection: Sync {
+pub trait Connection: Send + Sync {
     /// Send bytes in a packet across the connection in a blocking manner.
     fn send_packet(&mut self, bytes: &[u8]) -> crate::Result;
     /// Read a packet/request from the connection in a blocking manner.

--- a/src/display/output.rs
+++ b/src/display/output.rs
@@ -1,13 +1,62 @@
 // MIT/Apache2 License
 
-use super::{Connection, RequestCookie};
+use super::{Connection, RequestCookie, EXT_KEY_SIZE};
 use crate::{util::cycled_zeroes, Request};
+use alloc::string::ToString;
 use core::iter;
 use tinyvec::TinyVec;
 
+#[inline]
+fn string_as_array_bytes(s: &str) -> [u8; EXT_KEY_SIZE] {
+    let mut bytes: [u8; EXT_KEY_SIZE] = [0; EXT_KEY_SIZE];
+    if s.len() > EXT_KEY_SIZE {
+        bytes.copy_from_slice(&s.as_bytes()[..24]);
+    } else {
+        (&mut bytes[..s.len()]).copy_from_slice(s.as_bytes());
+    }
+    bytes
+}
+
 impl<Conn: Connection> super::Display<Conn> {
+    #[allow(clippy::single_match_else)]
     #[inline]
-    fn encode_request<R: Request>(&mut self, req: R) -> (u64, TinyVec<[u8; 32]>) {
+    fn get_ext_opcode(&mut self, extname: &'static str) -> crate::Result<u8> {
+        let sarr = string_as_array_bytes(extname);
+        match self.extensions.get(&sarr) {
+            Some(code) => Ok(*code),
+            None => {
+                let code = self
+                    .query_extension_immediate(extname.to_string())?
+                    .major_opcode;
+                self.extensions.insert(sarr, code);
+                Ok(code)
+            }
+        }
+    }
+
+    #[cfg(feature = "async")]
+    #[inline]
+    async fn get_ext_opcode_async(&mut self, extname: &'static str) -> crate::Result<u8> {
+        let sarr = string_as_array_bytes(extname);
+        match self.extensions.get(&sarr) {
+            Some(code) => Ok(*code),
+            None => {
+                let code = self
+                    .query_extension_immediate_async(extname.to_string())
+                    .await?
+                    .major_opcode;
+                self.extensions.insert(sarr, code);
+                Ok(code)
+            }
+        }
+    }
+
+    #[inline]
+    fn encode_request<R: Request>(
+        &mut self,
+        req: R,
+        ext_opcode: Option<u8>,
+    ) -> (u64, TinyVec<[u8; 32]>) {
         let sequence = self.request_number;
         self.request_number += 1;
 
@@ -27,12 +76,22 @@ impl<Conn: Connection> super::Display<Conn> {
             log::trace!("Extended length is now {}", len);
         }
 
-        // First byte is opcode
-        // Second byte is minor opcode (ignored for now)
-        // Third and fourth are length
-        log::debug!("Request has opcode {}", R::OPCODE);
-        bytes[0] = R::OPCODE;
+        match ext_opcode {
+            None => {
+                // First byte is opcode
+                // Second byte is minor opcode (ignored for now)
+                log::debug!("Request has opcode {}", R::OPCODE);
+                bytes[0] = R::OPCODE;
+            }
+            Some(extension) => {
+                // First byte is extension opcode
+                // Second byte is regular opcode
+                bytes[0] = extension;
+                bytes[1] = R::OPCODE;
+            }
+        }
 
+        // Third and fourth are length
         let x_len = len / 4;
         log::trace!("xlen is {}", x_len);
         let len_bytes = x_len.to_ne_bytes();
@@ -50,7 +109,11 @@ impl<Conn: Connection> super::Display<Conn> {
 
     #[inline]
     pub fn send_request_internal<R: Request>(&mut self, req: R) -> crate::Result<RequestCookie<R>> {
-        let (sequence, bytes): (u64, TinyVec<[u8; 32]>) = self.encode_request(req);
+        let ext_opcode = match R::EXTENSION {
+            None => None,
+            Some(ext) => Some(self.get_ext_opcode(ext)?),
+        };
+        let (sequence, bytes): (u64, TinyVec<[u8; 32]>) = self.encode_request(req, ext_opcode);
 
         self.connection.send_packet(&bytes)?;
         Ok(RequestCookie::from_sequence(sequence))
@@ -62,7 +125,11 @@ impl<Conn: Connection> super::Display<Conn> {
         &mut self,
         req: R,
     ) -> crate::Result<RequestCookie<R>> {
-        let (sequence, bytes) = self.encode_request(req);
+        let ext_opcode = match R::EXTENSION {
+            None => None,
+            Some(ext) => Some(self.get_ext_opcode_async(ext).await?),
+        };
+        let (sequence, bytes) = self.encode_request(req, ext_opcode);
 
         self.connection.send_packet_async(&bytes).await?;
         Ok(RequestCookie::from_sequence(sequence))

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum BreadError {
     /// BadReadError
     BadObjectRead(Option<&'static str>),
     /// Required extension was not present.
-    ExtensionNotPresent(&'static str),
+    ExtensionNotPresent,
     /// An error propogated by the X11 server.
     XProtocol {
         error_code: ErrorCode,
@@ -80,7 +80,7 @@ impl fmt::Display for BreadError {
                 "Unable to read object of type from bytes: {}",
                 name.unwrap_or("Unknown")
             ),
-            Self::ExtensionNotPresent(ext) => write!(f, "Unable to load extension {}", ext),
+            Self::ExtensionNotPresent => f.write_str("Extension was not found on X server"),
             Self::XProtocol {
                 error_code,
                 minor_code,

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -1,0 +1,29 @@
+// MIT/Apache2 License
+
+use super::auto::xproto::QueryExtensionReply;
+use core::convert::TryFrom;
+
+/// Data related to an extension.
+#[derive(Debug, Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+pub struct Extension {
+    pub major_opcode: u8,
+    pub first_event: u8,
+    pub first_error: u8,
+}
+
+impl TryFrom<QueryExtensionReply> for Extension {
+    type Error = crate::BreadError;
+
+    #[inline]
+    fn try_from(qer: QueryExtensionReply) -> crate::Result<Extension> {
+        if qer.present {
+            Ok(Self {
+                major_opcode: qer.major_opcode,
+                first_event: qer.first_event,
+                first_error: qer.first_error,
+            })
+        } else {
+            Err(crate::BreadError::ExtensionNotPresent)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub mod display;
 pub mod drawable;
 pub mod error;
 pub mod event;
+pub mod extension;
 pub mod gcontext;
 pub mod image;
 pub(crate) mod paramatizer;
@@ -148,6 +149,7 @@ pub use colormap::*;
 pub use display::*;
 pub use error::*;
 pub use event::Event;
+pub use extension::*;
 pub use gcontext::*;
 pub use image::Image;
 pub use pixmap::*;
@@ -161,6 +163,9 @@ pub trait Request: AsByteSequence {
     //
     // Every request contains an 8-bit major opcode
     const OPCODE: u8;
+
+    /// The name of the extension that this request belongs to.
+    const EXTENSION: Option<&'static str>;
 }
 
 //pub use display::*;


### PR DESCRIPTION
Modern X11 is defined by extensions. This PR adds basic support for extensions by:

* Adding an `EXTENSION` const field to the `Request` trait, defining a request's associated extension name.
* Adding an `extensions` field to `Display` that keeps track of extension names and their associated opcodes. The `send_request_*` family of methods now uses this to construct their requests.
* Add the `query_extension_*` family of methods to `Display`
* Add the `xrender` extension as a proof of concept.
* Fix a glitch in `breadx_generator` that I had not noticed yet.