### PR TITLE
Remodel the error handling system to correspond more directly to they function they originate from

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -14,7 +14,7 @@ use smol::{
     channel::{unbounded, Receiver, Sender},
     Executor, Timer,
 };
-use std::{mem, time::Duration};
+use std::{env, mem, time::Duration};
 
 // coroutine base: wait 3 seconds, generate three random numbers, and send them down the channel
 #[inline]
@@ -181,6 +181,9 @@ async fn entry(ex: &Executor<'_>) -> breadx::Result<()> {
 }
 
 fn main() -> breadx::Result<()> {
+    env::set_var("RUST_LOG", "breadx=trace");
+    env_logger::init();
+
     // spawn the executor
     let (signal, shutdown) = unbounded::<()>();
     let ex = Executor::new();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -94,6 +94,9 @@ fn main() {
                 let geometry = window.geometry_immediate(&mut conn).unwrap();
                 println!("Window is [{} x {}]", geometry.width, geometry.height);
 
+                // turn off checked mode to speed up painting
+                conn.set_checked(false);
+
                 let mut gc_params: GcParameters = Default::default();
                 gc_params.foreground = Some(red_clr);
                 gc.change(&mut conn, gc_params.clone()).unwrap();
@@ -168,6 +171,8 @@ fn main() {
                     },
                 )
                 .unwrap();
+
+                conn.set_checked(true);
             }
             _ => (),
         }

--- a/src/auth_info.rs
+++ b/src/auth_info.rs
@@ -142,7 +142,11 @@ impl AuthInfo {
     #[inline]
     pub(crate) fn get() -> Self {
         if let Some(mut v) = Self::from_xauthority() {
-            v.remove(0)
+            if v.is_empty() {
+                Default::default()
+            } else {
+                v.remove(0)
+            }
         } else {
             log::error!("Failed to get AuthInfo from XAUTHORITY, using empty auth info");
             Default::default()
@@ -153,7 +157,13 @@ impl AuthInfo {
     #[inline]
     pub(crate) async fn get_async() -> Self {
         match Self::from_xauthority_async().await {
-            Some(mut v) => v.remove(0),
+            Some(mut v) => {
+                if v.is_empty() {
+                    Default::default()
+                } else {
+                    v.remove(0)
+                }
+            }
             None => Default::default(),
         }
     }

--- a/src/auto/mod.rs
+++ b/src/auto/mod.rs
@@ -82,6 +82,7 @@ pub(crate) fn vector_from_bytes<T: AsByteSequence>(
     bytes: &[u8],
     len: usize,
 ) -> Option<(Vec<T>, usize)> {
+    #[cfg(debug_assertions)]
     log::trace!("Deserializing vector of byte length {} from bytes", len);
 
     // allocate the vector
@@ -238,6 +239,7 @@ macro_rules! impl_fundamental_num {
 
             #[inline]
             fn from_bytes(bytes: &[u8]) -> Option<(Self, usize)> {
+                #[cfg(debug_assertions)]
                 log::trace!("Deserializing {} from bytes", stringify!($t));
 
                 cfg_if::cfg_if! {

--- a/src/display/connection/unix.rs
+++ b/src/display/connection/unix.rs
@@ -92,6 +92,9 @@ pub async fn send_packet_unix_async<Conn: AsRawFd + Write + Unpin>(
     })
     .await?;
 
+    #[cfg(debug_assertions)]
+    log::trace!("Done with write_with()");
+
     Ok(())
 }
 

--- a/src/display/connection/unix.rs
+++ b/src/display/connection/unix.rs
@@ -103,22 +103,29 @@ pub async fn send_packet_unix_async<Conn: AsRawFd + Write + Unpin>(
 #[inline]
 fn read_msg_packet(conn: RawFd, mut data: &mut [u8], fds: &mut Vec<Fd>) -> io::Result<()> {
     const MAX_FDS: usize = 16;
+
+    if data.is_empty() {
+        return Ok(());
+    }
+
     let mut cmsg = nix::cmsg_space!([Fd; MAX_FDS]);
     let mut datalen = data.len();
     let mut datavec = [IoVec::from_mut_slice(data)];
 
     let msg = loop {
+        log::debug!("Calling recvmsg with a data buffer of length {}", datalen);
         match recvmsg(conn, &datavec, Some(&mut cmsg), MsgFlags::empty()) {
             Ok(m) if m.bytes == 0 => break m,
             Ok(m) if m.bytes == datalen => break m,
             Ok(m) => {
+                #[cfg(debug_assertions)]
                 log::debug!("recvmsg: yet to receive {} bytes", data.len() - m.bytes);
                 data = &mut data[m.bytes..];
                 datalen = data.len();
                 datavec = [IoVec::from_mut_slice(data)];
             }
             Err(nix::Error::Sys(nix::errno::Errno::EINTR)) => {
-                log::debug!("Interrupt occurred during read ");
+                log::info!("Interrupt occurred during read");
             }
             Err(e) => return Err(convert_nix_error(e)),
         }

--- a/src/display/functions/mod.rs
+++ b/src/display/functions/mod.rs
@@ -46,7 +46,7 @@ macro_rules! send_request {
             let tok = ($dpy).send_request_async(req).await?;
 
             #[cfg(debug_assertions)]
-            log::debug!("Sent {} to server.", stringify!($reqname));
+            log::debug!("Sent request to server.");
 
             Ok::<_, crate::BreadError>(tok)
         }

--- a/src/display/input.rs
+++ b/src/display/input.rs
@@ -20,24 +20,30 @@ impl<Conn> super::Display<Conn> {
     fn process_bytes(&mut self, mut bytes: TinyVec<[u8; 32]>, fds: Box<[Fd]>) -> crate::Result {
         // get the sequence number
         let sequence = u16::from_ne_bytes([bytes[2], bytes[3]]);
+        #[cfg(debug_assertions)]
         log::trace!("Found response bytes: {}", &bytes);
 
         if bytes[0] == TYPE_REPLY {
             log::debug!("Received bytes of type REPLY");
 
-            let _pereq = self
+            let pereq = self
                 .pending_requests
                 .remove(&sequence)
                 .ok_or(crate::BreadError::NoMatchingRequest(sequence))?;
 
-            // convert bytes to a boxed slice
-            bytes.move_to_the_heap();
-            let bytes = match bytes {
-                TinyVec::Heap(v) => v.into_boxed_slice(),
-                TinyVec::Inline(_) => unreachable!(),
-            };
+            // if we're discarding the reply, skip the conversion process
+            if pereq.flags.discard_reply {
+                log::debug!("Discarding input for request");
+            } else {
+                // convert bytes to a boxed slice
+                bytes.move_to_the_heap();
+                let bytes = match bytes {
+                    TinyVec::Heap(v) => v.into_boxed_slice(),
+                    TinyVec::Inline(_) => unreachable!(),
+                };
 
-            self.pending_replies.insert(sequence, (bytes, fds));
+                self.pending_replies.insert(sequence, (bytes, fds));
+            }
         } else if bytes[0] == TYPE_ERROR {
             // if it's all zeroes, the X connection has closed and the programmer
             // forgot to check for the close message
@@ -46,13 +52,27 @@ impl<Conn> super::Display<Conn> {
                 return Err(crate::BreadError::ClosedConnection);
             }
 
-            // XCB has some convoluted machinery for errors
-            // thank God Rust has better error handling
-            return Err(crate::BreadError::from_x_error(bytes));
+            let err = crate::BreadError::from_x_error(bytes);
+
+            // if we have a pending request with the given sequence, remove that pending
+            // request and put that in the pending requests
+            match self.pending_requests.remove(&sequence) {
+                Some(_) => {
+                    if self.pending_errors.insert(sequence, err).is_some() {
+                        panic!("Sequence number overflow - there are too many requests");
+                    }
+                }
+                // if there is no pending request, we've probably done something
+                // weird somewhere
+                // default to returning the error from the request that's currently
+                // calling wait()
+                None => return Err(err),
+            }
         } else {
             log::debug!("Received bytes of type EVENT");
             // this is an event
             let event = Event::from_bytes(bytes)?;
+            // if it doesn't fit in any of the special event queues, put it in the main one
             if let Err(event) = self.filter_into_special_event(event) {
                 self.event_queue.push_back(event);
             }

--- a/src/display/input.rs
+++ b/src/display/input.rs
@@ -190,6 +190,8 @@ impl<Conn: AsyncConnection + Send> super::Display<Conn> {
     // wait for bytes to appear, async redox
     #[inline]
     pub(crate) async fn wait_async(&mut self) -> crate::Result {
+        #[cfg(debug_assertions)]
+        log::debug!("Beginning wait cycle.");
         // see above function for more information
         let mut bytes: TinyVec<[u8; 32]> = cycled_zeroes(32);
         let mut fds: Vec<Fd> = vec![];


### PR DESCRIPTION
This pull request adds the `pending_errors` field to store errors corresponding to requests. In the past, errors were emitted whenever `wait()` received them which, in cases where multiple functions are being polled at once, could lead to an error being associated with the wrong result. When checked mode is enabled (via `Display::set_checked`), each void function will synchronize the display before checking its result via `pending_errors`.

This also fixes a bug with `read_msg_async` where it would try to call `recvmsg` on a zero-size slice when called via the async function.